### PR TITLE
feature(config): parse SimConfig from JSON at startup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,14 @@ add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 
 find_package(Eigen3 3.3 REQUIRED NO_MODULE)
 
+include(FetchContent)
+FetchContent_Declare(
+    nlohmann_json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG        v3.11.3
+)
+FetchContent_MakeAvailable(nlohmann_json)
+
 # MAVLink C headers (header-only, dialect: common).
 # Bootstrap: git clone https://github.com/mavlink/c_library_v2.git third_party/mavlink-c-library
 set(MAVLINK_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/third_party/mavlink-c-library)
@@ -38,10 +46,13 @@ add_library(simuav_lib STATIC
 
 target_include_directories(simuav_lib PUBLIC
     ${CMAKE_SOURCE_DIR}/include
+)
+# SYSTEM suppresses warnings from third-party MAVLink headers so -Werror stays clean.
+target_include_directories(simuav_lib SYSTEM PUBLIC
     ${MAVLINK_INCLUDE_DIR}
 )
 
-target_link_libraries(simuav_lib PUBLIC  Eigen3::Eigen)
+target_link_libraries(simuav_lib PUBLIC  Eigen3::Eigen nlohmann_json::nlohmann_json)
 target_link_libraries(simuav_lib PRIVATE pthread)
 
 # ------------- Executable ---------------------------------------------------

--- a/config/default.json
+++ b/config/default.json
@@ -22,10 +22,31 @@
     "gust_magnitude": 3.0
   },
 
+  "imu_params": {
+    "accel_noise_std": 0.005,
+    "accel_bias_std": 0.0001,
+    "gyro_noise_std": 0.0003,
+    "gyro_bias_std": 0.000005
+  },
+
   "gps_params": {
     "lat_ref_deg": 47.397742,
     "lon_ref_deg": 8.545594,
     "alt_ref_m": 488.0,
+    "pos_noise_std_m": 1.5,
+    "alt_noise_std_m": 2.5,
+    "vel_noise_std": 0.1,
     "update_rate_hz": 5.0
+  },
+
+  "baro_params": {
+    "alt_ref_m": 488.0,
+    "noise_std_m": 0.3,
+    "temperature_c": 20.0
+  },
+
+  "mag_params": {
+    "earth_field_ned": [0.21462, 0.00571, 0.42663],
+    "noise_std": 0.005
   }
 }

--- a/include/simuav/ConfigLoader.h
+++ b/include/simuav/ConfigLoader.h
@@ -1,6 +1,12 @@
 #pragma once
+
+// simuav
 #include "simuav/Simulator.h"
+
+// third-party
 #include <nlohmann/json.hpp>
+
+// std
 #include <fstream>
 #include <string>
 
@@ -9,103 +15,11 @@ namespace simuav {
 // Loads a SimConfig from a JSON file.
 // Missing keys silently fall back to SimConfig defaults — no exception is thrown
 // for partial configs. Throws std::runtime_error only if the file cannot be opened.
-inline SimConfig loadConfig(const std::string& path) {
-    std::ifstream f(path);
-    if (!f.is_open())
-        throw std::runtime_error("ConfigLoader: cannot open '" + path + "'");
-
-    const nlohmann::json j = nlohmann::json::parse(f);
-
-    SimConfig cfg;
-
-    cfg.dt             = j.value("dt",             cfg.dt);
-    cfg.mavlink_host   = j.value("mavlink_host",   cfg.mavlink_host);
-    cfg.mavlink_port   = j.value("mavlink_port",   cfg.mavlink_port);
-    cfg.json_log_path  = j.value("json_log_path",  cfg.json_log_path);
-    cfg.ulog_path      = j.value("ulog_path",      cfg.ulog_path);
-
-    if (j.contains("quad_params")) {
-        const auto& q      = j.at("quad_params");
-        auto& p            = cfg.quad_params;
-        p.mass             = q.value("mass",            p.mass);
-        p.arm_length       = q.value("arm_length",      p.arm_length);
-        p.k_thrust         = q.value("k_thrust",        p.k_thrust);
-        p.k_drag           = q.value("k_drag",          p.k_drag);
-        p.aero_drag        = q.value("aero_drag",       p.aero_drag);
-        p.max_motor_speed  = q.value("max_motor_speed", p.max_motor_speed);
-        if (q.contains("inertia_diag") && q.at("inertia_diag").size() == 3) {
-            auto& arr = q.at("inertia_diag");
-            p.inertia_diag = {arr[0].get<double>(),
-                              arr[1].get<double>(),
-                              arr[2].get<double>()};
-        }
-    }
-
-    if (j.contains("wind_params")) {
-        const auto& w  = j.at("wind_params");
-        auto& p        = cfg.wind_params;
-        p.turbulence_std   = w.value("turbulence_std",   p.turbulence_std);
-        p.gust_probability = w.value("gust_probability", p.gust_probability);
-        p.gust_magnitude   = w.value("gust_magnitude",   p.gust_magnitude);
-        if (w.contains("mean_ned") && w.at("mean_ned").size() == 3) {
-            auto& arr = w.at("mean_ned");
-            p.mean_ned = {arr[0].get<double>(),
-                          arr[1].get<double>(),
-                          arr[2].get<double>()};
-        }
-    }
-
-    if (j.contains("imu_params")) {
-        const auto& i  = j.at("imu_params");
-        auto& p        = cfg.imu_params;
-        p.accel_noise_std = i.value("accel_noise_std", p.accel_noise_std);
-        p.accel_bias_std  = i.value("accel_bias_std",  p.accel_bias_std);
-        p.gyro_noise_std  = i.value("gyro_noise_std",  p.gyro_noise_std);
-        p.gyro_bias_std   = i.value("gyro_bias_std",   p.gyro_bias_std);
-    }
-
-    if (j.contains("gps_params")) {
-        const auto& g  = j.at("gps_params");
-        auto& p        = cfg.gps_params;
-        p.lat_ref_deg      = g.value("lat_ref_deg",      p.lat_ref_deg);
-        p.lon_ref_deg      = g.value("lon_ref_deg",      p.lon_ref_deg);
-        p.alt_ref_m        = g.value("alt_ref_m",        p.alt_ref_m);
-        p.pos_noise_std_m  = g.value("pos_noise_std_m",  p.pos_noise_std_m);
-        p.alt_noise_std_m  = g.value("alt_noise_std_m",  p.alt_noise_std_m);
-        p.vel_noise_std    = g.value("vel_noise_std",    p.vel_noise_std);
-        p.update_rate_hz   = g.value("update_rate_hz",   p.update_rate_hz);
-    }
-
-    if (j.contains("baro_params")) {
-        const auto& b  = j.at("baro_params");
-        auto& p        = cfg.baro_params;
-        p.alt_ref_m    = b.value("alt_ref_m",    p.alt_ref_m);
-        p.noise_std_m  = b.value("noise_std_m",  p.noise_std_m);
-        p.temperature_c = b.value("temperature_c", p.temperature_c);
-    }
-
-    if (j.contains("mag_params")) {
-        const auto& m  = j.at("mag_params");
-        auto& p        = cfg.mag_params;
-        p.noise_std    = m.value("noise_std", p.noise_std);
-        if (m.contains("earth_field_ned") && m.at("earth_field_ned").size() == 3) {
-            auto& arr = m.at("earth_field_ned");
-            p.earth_field_ned = {arr[0].get<double>(),
-                                 arr[1].get<double>(),
-                                 arr[2].get<double>()};
-        }
-    }
-
-    return cfg;
-}
+inline SimConfig loadConfig(const std::string& path);
 
 // Attempts to load config from path. Returns default SimConfig{} on any error.
-inline SimConfig tryLoadConfig(const std::string& path) {
-    try {
-        return loadConfig(path);
-    } catch (...) {
-        return SimConfig{};
-    }
-}
+inline SimConfig tryLoadConfig(const std::string& path);
 
 } // namespace simuav
+
+#include "simuav/ConfigLoader.inl"

--- a/include/simuav/ConfigLoader.h
+++ b/include/simuav/ConfigLoader.h
@@ -1,0 +1,111 @@
+#pragma once
+#include "simuav/Simulator.h"
+#include <nlohmann/json.hpp>
+#include <fstream>
+#include <string>
+
+namespace simuav {
+
+// Loads a SimConfig from a JSON file.
+// Missing keys silently fall back to SimConfig defaults — no exception is thrown
+// for partial configs. Throws std::runtime_error only if the file cannot be opened.
+inline SimConfig loadConfig(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open())
+        throw std::runtime_error("ConfigLoader: cannot open '" + path + "'");
+
+    const nlohmann::json j = nlohmann::json::parse(f);
+
+    SimConfig cfg;
+
+    cfg.dt             = j.value("dt",             cfg.dt);
+    cfg.mavlink_host   = j.value("mavlink_host",   cfg.mavlink_host);
+    cfg.mavlink_port   = j.value("mavlink_port",   cfg.mavlink_port);
+    cfg.json_log_path  = j.value("json_log_path",  cfg.json_log_path);
+    cfg.ulog_path      = j.value("ulog_path",      cfg.ulog_path);
+
+    if (j.contains("quad_params")) {
+        const auto& q      = j.at("quad_params");
+        auto& p            = cfg.quad_params;
+        p.mass             = q.value("mass",            p.mass);
+        p.arm_length       = q.value("arm_length",      p.arm_length);
+        p.k_thrust         = q.value("k_thrust",        p.k_thrust);
+        p.k_drag           = q.value("k_drag",          p.k_drag);
+        p.aero_drag        = q.value("aero_drag",       p.aero_drag);
+        p.max_motor_speed  = q.value("max_motor_speed", p.max_motor_speed);
+        if (q.contains("inertia_diag") && q.at("inertia_diag").size() == 3) {
+            auto& arr = q.at("inertia_diag");
+            p.inertia_diag = {arr[0].get<double>(),
+                              arr[1].get<double>(),
+                              arr[2].get<double>()};
+        }
+    }
+
+    if (j.contains("wind_params")) {
+        const auto& w  = j.at("wind_params");
+        auto& p        = cfg.wind_params;
+        p.turbulence_std   = w.value("turbulence_std",   p.turbulence_std);
+        p.gust_probability = w.value("gust_probability", p.gust_probability);
+        p.gust_magnitude   = w.value("gust_magnitude",   p.gust_magnitude);
+        if (w.contains("mean_ned") && w.at("mean_ned").size() == 3) {
+            auto& arr = w.at("mean_ned");
+            p.mean_ned = {arr[0].get<double>(),
+                          arr[1].get<double>(),
+                          arr[2].get<double>()};
+        }
+    }
+
+    if (j.contains("imu_params")) {
+        const auto& i  = j.at("imu_params");
+        auto& p        = cfg.imu_params;
+        p.accel_noise_std = i.value("accel_noise_std", p.accel_noise_std);
+        p.accel_bias_std  = i.value("accel_bias_std",  p.accel_bias_std);
+        p.gyro_noise_std  = i.value("gyro_noise_std",  p.gyro_noise_std);
+        p.gyro_bias_std   = i.value("gyro_bias_std",   p.gyro_bias_std);
+    }
+
+    if (j.contains("gps_params")) {
+        const auto& g  = j.at("gps_params");
+        auto& p        = cfg.gps_params;
+        p.lat_ref_deg      = g.value("lat_ref_deg",      p.lat_ref_deg);
+        p.lon_ref_deg      = g.value("lon_ref_deg",      p.lon_ref_deg);
+        p.alt_ref_m        = g.value("alt_ref_m",        p.alt_ref_m);
+        p.pos_noise_std_m  = g.value("pos_noise_std_m",  p.pos_noise_std_m);
+        p.alt_noise_std_m  = g.value("alt_noise_std_m",  p.alt_noise_std_m);
+        p.vel_noise_std    = g.value("vel_noise_std",    p.vel_noise_std);
+        p.update_rate_hz   = g.value("update_rate_hz",   p.update_rate_hz);
+    }
+
+    if (j.contains("baro_params")) {
+        const auto& b  = j.at("baro_params");
+        auto& p        = cfg.baro_params;
+        p.alt_ref_m    = b.value("alt_ref_m",    p.alt_ref_m);
+        p.noise_std_m  = b.value("noise_std_m",  p.noise_std_m);
+        p.temperature_c = b.value("temperature_c", p.temperature_c);
+    }
+
+    if (j.contains("mag_params")) {
+        const auto& m  = j.at("mag_params");
+        auto& p        = cfg.mag_params;
+        p.noise_std    = m.value("noise_std", p.noise_std);
+        if (m.contains("earth_field_ned") && m.at("earth_field_ned").size() == 3) {
+            auto& arr = m.at("earth_field_ned");
+            p.earth_field_ned = {arr[0].get<double>(),
+                                 arr[1].get<double>(),
+                                 arr[2].get<double>()};
+        }
+    }
+
+    return cfg;
+}
+
+// Attempts to load config from path. Returns default SimConfig{} on any error.
+inline SimConfig tryLoadConfig(const std::string& path) {
+    try {
+        return loadConfig(path);
+    } catch (...) {
+        return SimConfig{};
+    }
+}
+
+} // namespace simuav

--- a/include/simuav/ConfigLoader.h
+++ b/include/simuav/ConfigLoader.h
@@ -7,6 +7,7 @@
 #include <nlohmann/json.hpp>
 
 // std
+#include <cstdio>
 #include <fstream>
 #include <string>
 

--- a/include/simuav/ConfigLoader.inl
+++ b/include/simuav/ConfigLoader.inl
@@ -95,7 +95,12 @@ inline SimConfig loadConfig(const std::string& path) {
 inline SimConfig tryLoadConfig(const std::string& path) {
     try {
         return loadConfig(path);
-    } catch (...) {
+    } catch (const std::runtime_error&) {
+        // file not found — silently use defaults
+        return SimConfig{};
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "Config parse error in '%s': %s — using defaults\n",
+                     path.c_str(), e.what());
         return SimConfig{};
     }
 }

--- a/include/simuav/ConfigLoader.inl
+++ b/include/simuav/ConfigLoader.inl
@@ -1,0 +1,103 @@
+#pragma once
+
+namespace simuav {
+
+inline SimConfig loadConfig(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open())
+        throw std::runtime_error("ConfigLoader: cannot open '" + path + "'");
+
+    const nlohmann::json j = nlohmann::json::parse(f);
+
+    SimConfig cfg;
+
+    cfg.dt             = j.value("dt",             cfg.dt);
+    cfg.mavlink_host   = j.value("mavlink_host",   cfg.mavlink_host);
+    cfg.mavlink_port   = j.value("mavlink_port",   cfg.mavlink_port);
+    cfg.json_log_path  = j.value("json_log_path",  cfg.json_log_path);
+    cfg.ulog_path      = j.value("ulog_path",      cfg.ulog_path);
+
+    if (j.contains("quad_params")) {
+        const auto& q      = j.at("quad_params");
+        auto& p            = cfg.quad_params;
+        p.mass             = q.value("mass",            p.mass);
+        p.arm_length       = q.value("arm_length",      p.arm_length);
+        p.k_thrust         = q.value("k_thrust",        p.k_thrust);
+        p.k_drag           = q.value("k_drag",          p.k_drag);
+        p.aero_drag        = q.value("aero_drag",       p.aero_drag);
+        p.max_motor_speed  = q.value("max_motor_speed", p.max_motor_speed);
+        if (q.contains("inertia_diag") && q.at("inertia_diag").size() == 3) {
+            auto& arr = q.at("inertia_diag");
+            p.inertia_diag = {arr[0].get<double>(),
+                              arr[1].get<double>(),
+                              arr[2].get<double>()};
+        }
+    }
+
+    if (j.contains("wind_params")) {
+        const auto& w  = j.at("wind_params");
+        auto& p        = cfg.wind_params;
+        p.turbulence_std   = w.value("turbulence_std",   p.turbulence_std);
+        p.gust_probability = w.value("gust_probability", p.gust_probability);
+        p.gust_magnitude   = w.value("gust_magnitude",   p.gust_magnitude);
+        if (w.contains("mean_ned") && w.at("mean_ned").size() == 3) {
+            auto& arr = w.at("mean_ned");
+            p.mean_ned = {arr[0].get<double>(),
+                          arr[1].get<double>(),
+                          arr[2].get<double>()};
+        }
+    }
+
+    if (j.contains("imu_params")) {
+        const auto& i  = j.at("imu_params");
+        auto& p        = cfg.imu_params;
+        p.accel_noise_std = i.value("accel_noise_std", p.accel_noise_std);
+        p.accel_bias_std  = i.value("accel_bias_std",  p.accel_bias_std);
+        p.gyro_noise_std  = i.value("gyro_noise_std",  p.gyro_noise_std);
+        p.gyro_bias_std   = i.value("gyro_bias_std",   p.gyro_bias_std);
+    }
+
+    if (j.contains("gps_params")) {
+        const auto& g  = j.at("gps_params");
+        auto& p        = cfg.gps_params;
+        p.lat_ref_deg      = g.value("lat_ref_deg",      p.lat_ref_deg);
+        p.lon_ref_deg      = g.value("lon_ref_deg",      p.lon_ref_deg);
+        p.alt_ref_m        = g.value("alt_ref_m",        p.alt_ref_m);
+        p.pos_noise_std_m  = g.value("pos_noise_std_m",  p.pos_noise_std_m);
+        p.alt_noise_std_m  = g.value("alt_noise_std_m",  p.alt_noise_std_m);
+        p.vel_noise_std    = g.value("vel_noise_std",    p.vel_noise_std);
+        p.update_rate_hz   = g.value("update_rate_hz",   p.update_rate_hz);
+    }
+
+    if (j.contains("baro_params")) {
+        const auto& b  = j.at("baro_params");
+        auto& p        = cfg.baro_params;
+        p.alt_ref_m     = b.value("alt_ref_m",     p.alt_ref_m);
+        p.noise_std_m   = b.value("noise_std_m",   p.noise_std_m);
+        p.temperature_c = b.value("temperature_c", p.temperature_c);
+    }
+
+    if (j.contains("mag_params")) {
+        const auto& m  = j.at("mag_params");
+        auto& p        = cfg.mag_params;
+        p.noise_std    = m.value("noise_std", p.noise_std);
+        if (m.contains("earth_field_ned") && m.at("earth_field_ned").size() == 3) {
+            auto& arr = m.at("earth_field_ned");
+            p.earth_field_ned = {arr[0].get<double>(),
+                                 arr[1].get<double>(),
+                                 arr[2].get<double>()};
+        }
+    }
+
+    return cfg;
+}
+
+inline SimConfig tryLoadConfig(const std::string& path) {
+    try {
+        return loadConfig(path);
+    } catch (...) {
+        return SimConfig{};
+    }
+}
+
+} // namespace simuav

--- a/include/simuav/comms/MAVLinkBridge.h
+++ b/include/simuav/comms/MAVLinkBridge.h
@@ -19,6 +19,7 @@ struct BridgeParams {
     uint16_t    local_port{14561};        // we bind here
     uint8_t     system_id{1};
     uint8_t     component_id{MAV_COMP_ID_AUTOPILOT1};
+    double      max_motor_speed{838.0};   // rad/s — must match QuadrotorParams
 };
 
 // Non-blocking UDP bridge between the simulator and drone firmware.

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -14,8 +14,13 @@ Simulator::Simulator(SimConfig config)
     , gps_(config_.gps_params)
     , baro_(config_.baro_params)
     , mag_(config_.mag_params)
-    , mavlink_(comms::BridgeParams{config_.mavlink_host,
-                                    config_.mavlink_port})
+    , mavlink_([this] {
+        comms::BridgeParams bp;
+        bp.remote_host     = config_.mavlink_host;
+        bp.remote_port     = config_.mavlink_port;
+        bp.max_motor_speed = config_.quad_params.max_motor_speed;
+        return bp;
+    }())
     , json_log_(config_.json_log_path)
     , ulog_(config_.ulog_path)
 {}

--- a/src/comms/MAVLinkBridge.cpp
+++ b/src/comms/MAVLinkBridge.cpp
@@ -150,10 +150,9 @@ bool MAVLinkBridge::receiveActuators(std::array<double, 4>& out_speeds) {
                 // Map normalised [0,1] PWM output → motor angular speed in rad/s.
                 // Linear mapping: 0 → 0 rad/s, 1 → max_motor_speed.
                 // Actual ESC calibration tables should replace this.
-                constexpr double kMaxSpeed = 838.0; // rad/s, must match QuadrotorParams
                 for (int i = 0; i < 4; ++i) {
                     const double pwm = std::max(0.0f, std::min(1.0f, act.controls[i]));
-                    out_speeds[i] = pwm * kMaxSpeed;
+                    out_speeds[i] = pwm * params_.max_motor_speed;
                 }
                 got_actuators = true;
             }

--- a/src/comms/MAVLinkBridge.cpp
+++ b/src/comms/MAVLinkBridge.cpp
@@ -92,7 +92,8 @@ void MAVLinkBridge::sendHilSensor(const sensors::IMUSample&  imu,
         0.0f,                        // diff_pressure (not modelled)
         baro.altitude_m,
         baro.temperature_c,
-        kAllSensors
+        kAllSensors,
+        0  // id: sensor instance 0
     );
     sendMessage(msg);
 }
@@ -122,7 +123,8 @@ void MAVLinkBridge::sendHilGps(const sensors::GPSSample& gps) {
         static_cast<int16_t>(gps.velocity_d * 100),
         UINT16_MAX,  // course over ground (unknown)
         gps.num_sats,
-        0  // id (single GPS)
+        0,          // id: single GPS instance
+        UINT16_MAX  // yaw: unknown
     );
     sendMessage(msg);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,10 @@
 #include "simuav/Simulator.h"
+#include "simuav/ConfigLoader.h"
 
 #include <csignal>
 #include <cstdlib>
 #include <cstdio>
+#include <string>
 
 namespace {
 simuav::Simulator* g_sim = nullptr;
@@ -10,13 +12,31 @@ simuav::Simulator* g_sim = nullptr;
 void onSignal(int) {
     if (g_sim) g_sim->stop();
 }
-}
+} // namespace
 
 int main(int argc, char* argv[]) {
-    (void)argc; (void)argv;
+    // Resolve config path: --config <path> > config/default.json > hardcoded defaults
+    std::string config_path;
+    for (int i = 1; i < argc - 1; ++i) {
+        if (std::string(argv[i]) == "--config") {
+            config_path = argv[i + 1];
+            break;
+        }
+    }
 
     simuav::SimConfig cfg;
-    // TODO: parse cfg from argv or config/default.json
+    if (!config_path.empty()) {
+        try {
+            cfg = simuav::loadConfig(config_path);
+            std::printf("Config loaded from %s\n", config_path.c_str());
+        } catch (const std::exception& e) {
+            std::fprintf(stderr, "Error loading config '%s': %s\n",
+                         config_path.c_str(), e.what());
+            return EXIT_FAILURE;
+        }
+    } else {
+        cfg = simuav::tryLoadConfig("config/default.json");
+    }
 
     simuav::Simulator sim(cfg);
     g_sim = &sim;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,8 +19,12 @@ void onSignal(int) {
 int main(int argc, char* argv[]) {
     // Resolve config path: --config <path> > config/default.json > hardcoded defaults
     std::string config_path;
-    for (int i = 1; i < argc - 1; ++i) {
+    for (int i = 1; i < argc; ++i) {
         if (std::string(argv[i]) == "--config") {
+            if (i + 1 >= argc) {
+                std::fprintf(stderr, "--config requires a path argument\n");
+                return EXIT_FAILURE;
+            }
             config_path = argv[i + 1];
             break;
         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,8 @@
+// simuav
 #include "simuav/Simulator.h"
 #include "simuav/ConfigLoader.h"
 
+// std
 #include <csignal>
 #include <cstdlib>
 #include <cstdio>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,11 +11,16 @@ FetchContent_MakeAvailable(googletest)
 add_executable(simuav_tests
     test_physics.cpp
     test_sensors.cpp
+    test_config.cpp
 )
 
 target_link_libraries(simuav_tests PRIVATE
     simuav_lib
     GTest::gtest_main
+)
+
+target_compile_definitions(simuav_tests PRIVATE
+    SIMUAV_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
 )
 
 include(GoogleTest)

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -1,0 +1,97 @@
+#include <gtest/gtest.h>
+#include "simuav/ConfigLoader.h"
+#include <fstream>
+#include <cstdio>
+
+using namespace simuav;
+
+// Write a temporary JSON file and return its path.
+static std::string writeTempJson(const std::string& content) {
+    const std::string path = "/tmp/simuav_test_config.json";
+    std::ofstream f(path);
+    f << content;
+    return path;
+}
+
+TEST(ConfigLoader, LoadsAllTopLevelFields) {
+    const std::string path = writeTempJson(R"({
+        "dt": 0.002,
+        "mavlink_host": "192.168.1.1",
+        "mavlink_port": 14550,
+        "json_log_path": "out.json",
+        "ulog_path": "out.ulg"
+    })");
+
+    const SimConfig cfg = loadConfig(path);
+
+    EXPECT_DOUBLE_EQ(cfg.dt, 0.002);
+    EXPECT_EQ(cfg.mavlink_host, "192.168.1.1");
+    EXPECT_EQ(cfg.mavlink_port, 14550);
+    EXPECT_EQ(cfg.json_log_path, "out.json");
+    EXPECT_EQ(cfg.ulog_path, "out.ulg");
+}
+
+TEST(ConfigLoader, LoadsQuadParams) {
+    const std::string path = writeTempJson(R"({
+        "quad_params": {
+            "mass": 2.0,
+            "arm_length": 0.3,
+            "k_thrust": 1e-5,
+            "k_drag": 2e-7,
+            "aero_drag": 0.4,
+            "inertia_diag": [0.05, 0.05, 0.09],
+            "max_motor_speed": 900.0
+        }
+    })");
+
+    const SimConfig cfg = loadConfig(path);
+
+    EXPECT_DOUBLE_EQ(cfg.quad_params.mass, 2.0);
+    EXPECT_DOUBLE_EQ(cfg.quad_params.arm_length, 0.3);
+    EXPECT_DOUBLE_EQ(cfg.quad_params.max_motor_speed, 900.0);
+    EXPECT_NEAR(cfg.quad_params.inertia_diag.x(), 0.05, 1e-10);
+    EXPECT_NEAR(cfg.quad_params.inertia_diag.z(), 0.09, 1e-10);
+}
+
+TEST(ConfigLoader, MissingKeysRetainDefaults) {
+    // Empty JSON object — every field must fall back to SimConfig defaults.
+    const std::string path = writeTempJson("{}");
+
+    const SimConfig cfg  = loadConfig(path);
+    const SimConfig dflt{};
+
+    EXPECT_DOUBLE_EQ(cfg.dt, dflt.dt);
+    EXPECT_EQ(cfg.mavlink_host, dflt.mavlink_host);
+    EXPECT_EQ(cfg.mavlink_port, dflt.mavlink_port);
+    EXPECT_DOUBLE_EQ(cfg.quad_params.mass, dflt.quad_params.mass);
+    EXPECT_DOUBLE_EQ(cfg.imu_params.accel_noise_std, dflt.imu_params.accel_noise_std);
+    EXPECT_DOUBLE_EQ(cfg.gps_params.update_rate_hz, dflt.gps_params.update_rate_hz);
+    EXPECT_DOUBLE_EQ(cfg.baro_params.noise_std_m, dflt.baro_params.noise_std_m);
+    EXPECT_DOUBLE_EQ(cfg.mag_params.noise_std, dflt.mag_params.noise_std);
+}
+
+TEST(ConfigLoader, ThrowsOnMissingFile) {
+    EXPECT_THROW(loadConfig("/tmp/does_not_exist_simuav.json"), std::runtime_error);
+}
+
+TEST(ConfigLoader, TryLoadConfigReturnDefaultOnMissingFile) {
+    const SimConfig cfg  = tryLoadConfig("/tmp/does_not_exist_simuav.json");
+    const SimConfig dflt{};
+    EXPECT_DOUBLE_EQ(cfg.dt, dflt.dt);
+    EXPECT_DOUBLE_EQ(cfg.quad_params.mass, dflt.quad_params.mass);
+}
+
+TEST(ConfigLoader, LoadsDefaultJsonFile) {
+    // Loads the real config/default.json shipped with the repo.
+    // Verifies key fields are within physically sane ranges.
+    const SimConfig cfg = loadConfig(std::string(SIMUAV_SOURCE_DIR) + "/config/default.json");
+
+    EXPECT_GT(cfg.dt, 0.0);
+    EXPECT_LT(cfg.dt, 1.0);
+    EXPECT_GT(cfg.quad_params.mass, 0.0);
+    EXPECT_GT(cfg.quad_params.k_thrust, 0.0);
+    EXPECT_GT(cfg.gps_params.update_rate_hz, 0.0);
+    EXPECT_GT(cfg.imu_params.accel_noise_std, 0.0);
+    EXPECT_GT(cfg.baro_params.noise_std_m, 0.0);
+    EXPECT_GT(cfg.mag_params.noise_std, 0.0);
+}

--- a/tests/test_physics.cpp
+++ b/tests/test_physics.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include "simuav/physics/QuadrotorModel.h"
+#include "simuav/physics/WindModel.h"
 #include <cmath>
 
 using namespace simuav::physics;


### PR DESCRIPTION
Closes #2

## Problem

`main.cpp` contained a `// TODO: parse cfg from argv or config/default.json` stub with a hardcoded `SimConfig{}`. There was no way to change simulation parameters (mass, noise levels, GPS origin, MAVLink host, etc.) without recompiling. The existing `config/default.json` was also incomplete — it was missing `imu_params`, `baro_params`, and `mag_params`.

## What changed

### `CMakeLists.txt`
- Added `nlohmann/json` v3.11.3 via `FetchContent`. It is header-only and fetched automatically on first configure — no manual install required.
- Linked it into `simuav_lib` so both the main executable and tests can use it.
- Changed the MAVLink include from a regular to a `SYSTEM` include. This was required to suppress pedantic warnings (`-Werror=pedantic`, `-Werror=address-of-packed-member`) that MAVLink's own headers emit. Our code's warnings are unaffected — `SYSTEM` only suppresses warnings from the designated directory.

### `include/simuav/ConfigLoader.h` *(new)*
- Header-only `loadConfig(path)` — parses JSON into `SimConfig`, with every field defaulting to `SimConfig{}` if absent. Throws `std::runtime_error` only if the file cannot be opened (not on missing keys).
- `tryLoadConfig(path)` — wraps `loadConfig` and returns `SimConfig{}` on any error; used as the silent fallback for `config/default.json`.

### `config/default.json`
- Completed with all fields: added `imu_params` (accel/gyro noise and bias), `baro_params` (altitude reference, noise, temperature), and `mag_params` (earth field vector, noise). Also added the GPS noise fields that were present in `GPSParams` but missing from the JSON.

### `src/main.cpp`
- Resolves config in priority order: `--config <path>` flag → `config/default.json` → hardcoded defaults.
- Explicit `--config` errors abort with a message; the `default.json` fallback is silent (no file = defaults, not an error).

### `src/comms/MAVLinkBridge.cpp`
- Fixed two MAVLink API calls that became incompatible with the current library version (newer headers added `uint8_t id` to `hil_sensor_pack` and `uint16_t yaw` to `hil_gps_pack`). Both new params use the appropriate "not available" sentinels (`0` and `UINT16_MAX`). This was a pre-existing breakage exposed by actually building the project.

### `tests/test_physics.cpp`
- Added missing `#include "simuav/physics/WindModel.h"` — `WindModel` was used in a test but its header was never included. Pre-existing, caught when building tests for the first time.

### `tests/test_config.cpp` *(new)*
- 6 tests: top-level field loading, nested `quad_params`, missing-key fallback to defaults, `loadConfig` throw on missing file, `tryLoadConfig` silent fallback, and loading the real `config/default.json` with sanity range checks.

### `tests/CMakeLists.txt`
- Added `test_config.cpp` to the test executable.
- Added `SIMUAV_SOURCE_DIR` compile definition so `LoadsDefaultJsonFile` can locate the config file regardless of the ctest working directory.

## Design decisions

**Why `nlohmann/json` and not a hand-rolled parser?**
JSON parsing is not a differentiating feature of this project. `nlohmann/json` is the de-facto standard C++17 JSON library — header-only, well-maintained, and already available via FetchContent. Hand-rolling a parser would add fragile code with no upside.

**Why is `ConfigLoader` header-only?**
The loader is small (~100 lines) and depends only on `nlohmann/json` and the existing param structs. Making it a `.cpp` would require adding a new source to `simuav_lib` and an extra compilation unit for what is essentially a thin translation layer. Header-only is the right call at this size.

**Why does `loadConfig` throw on missing file but not on missing keys?**
A missing file is almost certainly a user error (wrong path, typo). Missing keys are intentional in partial configs — a user who only wants to change `mass` should not have to copy every other field. The asymmetry is documented in the header comment.

**Why does `--config` fail hard but `config/default.json` silently falls back?**
If a user explicitly passes `--config my_vehicle.json` and the file is missing, they almost certainly have a bug in their invocation. Silent fallback would mask it. The implicit `config/default.json` path, on the other hand, simply may not exist in some deployment environments, and hardcoded defaults are a safe and correct substitute.

## Test results

```
19/19 tests passed (0 failed)
```