### PR TITLE
feature(comms): replace linear PWM→rad/s with configurable ESC power-law curve

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -12,7 +12,9 @@
     "k_drag": 1.35e-7,
     "aero_drag": 0.25,
     "inertia_diag": [0.029, 0.029, 0.055],
-    "max_motor_speed": 838.0
+    "max_motor_speed": 838.0,
+    "esc_exponent": 0.5,
+    "motor_spin_min": 0.0
   },
 
   "wind_params": {

--- a/include/simuav/ConfigLoader.inl
+++ b/include/simuav/ConfigLoader.inl
@@ -26,6 +26,8 @@ inline SimConfig loadConfig(const std::string& path) {
         p.k_drag           = q.value("k_drag",          p.k_drag);
         p.aero_drag        = q.value("aero_drag",       p.aero_drag);
         p.max_motor_speed  = q.value("max_motor_speed", p.max_motor_speed);
+        p.esc_exponent     = q.value("esc_exponent",    p.esc_exponent);
+        p.motor_spin_min   = q.value("motor_spin_min",  p.motor_spin_min);
         if (q.contains("inertia_diag") && q.at("inertia_diag").size() == 3) {
             auto& arr = q.at("inertia_diag");
             p.inertia_diag = {arr[0].get<double>(),

--- a/include/simuav/comms/MAVLinkBridge.h
+++ b/include/simuav/comms/MAVLinkBridge.h
@@ -20,6 +20,8 @@ struct BridgeParams {
     uint8_t     system_id{1};
     uint8_t     component_id{MAV_COMP_ID_AUTOPILOT1};
     double      max_motor_speed{838.0};   // rad/s — must match QuadrotorParams
+    double      esc_exponent{0.5};        // power-law exponent for throttle→speed curve
+    double      motor_spin_min{0.0};      // rad/s — idle speed at zero throttle
 };
 
 // Non-blocking UDP bridge between the simulator and drone firmware.
@@ -48,6 +50,11 @@ public:
     // Drains the receive buffer. Returns true if new actuator data was read.
     // out_speeds: motor angular speeds in rad/s (indices match QuadrotorModel).
     bool receiveActuators(std::array<double, 4>& out_speeds);
+
+    // Maps normalised throttle [0,1] → rad/s using a power-law ESC curve.
+    // ω = motor_spin_min + (max_motor_speed − motor_spin_min) × clamp(throttle,0,1)^exponent
+    static double escToSpeed(double throttle, double max_motor_speed,
+                             double motor_spin_min, double exponent);
 
 private:
     void sendMessage(const mavlink_message_t& msg);

--- a/include/simuav/physics/QuadrotorModel.h
+++ b/include/simuav/physics/QuadrotorModel.h
@@ -29,6 +29,8 @@ struct QuadrotorParams {
     // Diagonal inertia tensor [Ixx, Iyy, Izz] (kg·m²)
     Eigen::Vector3d inertia_diag{0.029, 0.029, 0.055};
     double max_motor_speed{838.0};  // rad/s (~8 000 RPM)
+    double esc_exponent{0.5};       // throttle→speed power law: 0.5 = thrust-linear, 1.0 = speed-linear
+    double motor_spin_min{0.0};     // rad/s — motor speed at zero throttle (idle)
 };
 
 // Full rigid-body state expressed in NED world frame.

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -19,6 +19,8 @@ Simulator::Simulator(SimConfig config)
         bp.remote_host     = config_.mavlink_host;
         bp.remote_port     = config_.mavlink_port;
         bp.max_motor_speed = config_.quad_params.max_motor_speed;
+        bp.esc_exponent    = config_.quad_params.esc_exponent;
+        bp.motor_spin_min  = config_.quad_params.motor_spin_min;
         return bp;
     }())
     , json_log_(config_.json_log_path)

--- a/src/comms/MAVLinkBridge.cpp
+++ b/src/comms/MAVLinkBridge.cpp
@@ -147,18 +147,24 @@ bool MAVLinkBridge::receiveActuators(std::array<double, 4>& out_speeds) {
                 mavlink_hil_actuator_controls_t act{};
                 mavlink_msg_hil_actuator_controls_decode(&msg, &act);
 
-                // Map normalised [0,1] PWM output → motor angular speed in rad/s.
-                // Linear mapping: 0 → 0 rad/s, 1 → max_motor_speed.
-                // Actual ESC calibration tables should replace this.
                 for (int i = 0; i < 4; ++i) {
-                    const double pwm = std::max(0.0f, std::min(1.0f, act.controls[i]));
-                    out_speeds[i] = pwm * params_.max_motor_speed;
+                    out_speeds[i] = escToSpeed(
+                        static_cast<double>(act.controls[i]),
+                        params_.max_motor_speed,
+                        params_.motor_spin_min,
+                        params_.esc_exponent);
                 }
                 got_actuators = true;
             }
         }
     }
     return got_actuators;
+}
+
+double MAVLinkBridge::escToSpeed(double throttle, double max_motor_speed,
+                                  double motor_spin_min, double exponent) {
+    const double t = std::max(0.0, std::min(1.0, throttle));
+    return motor_spin_min + (max_motor_speed - motor_spin_min) * std::pow(t, exponent);
 }
 
 }  // namespace simuav::comms

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(simuav_tests
     test_physics.cpp
     test_sensors.cpp
     test_config.cpp
+    test_bridge.cpp
 )
 
 target_link_libraries(simuav_tests PRIVATE

--- a/tests/test_bridge.cpp
+++ b/tests/test_bridge.cpp
@@ -1,0 +1,38 @@
+// simuav
+#include "simuav/comms/MAVLinkBridge.h"
+
+// third-party
+#include <gtest/gtest.h>
+
+using simuav::comms::MAVLinkBridge;
+
+TEST(ESCCurve, LinearExponentGivesLinearSpeedMapping) {
+    EXPECT_DOUBLE_EQ(MAVLinkBridge::escToSpeed(0.0, 838.0, 0.0, 1.0), 0.0);
+    EXPECT_DOUBLE_EQ(MAVLinkBridge::escToSpeed(0.5, 838.0, 0.0, 1.0), 419.0);
+    EXPECT_DOUBLE_EQ(MAVLinkBridge::escToSpeed(1.0, 838.0, 0.0, 1.0), 838.0);
+}
+
+TEST(ESCCurve, SqrtExponentGivesThrustLinearBehavior) {
+    // exponent=0.5: ω = max * sqrt(throttle), so thrust ∝ throttle
+    EXPECT_DOUBLE_EQ(MAVLinkBridge::escToSpeed(0.0,  838.0, 0.0, 0.5), 0.0);
+    EXPECT_DOUBLE_EQ(MAVLinkBridge::escToSpeed(1.0,  838.0, 0.0, 0.5), 838.0);
+    // sqrt(0.25) = 0.5 → half max speed at quarter throttle
+    EXPECT_NEAR(MAVLinkBridge::escToSpeed(0.25, 838.0, 0.0, 0.5), 419.0, 1e-9);
+}
+
+TEST(ESCCurve, ThrottleClampsAtBoundaries) {
+    EXPECT_DOUBLE_EQ(MAVLinkBridge::escToSpeed(-1.0, 838.0, 0.0, 0.5), 0.0);
+    EXPECT_DOUBLE_EQ(MAVLinkBridge::escToSpeed( 2.0, 838.0, 0.0, 0.5), 838.0);
+}
+
+TEST(ESCCurve, SpinMinAppliedAtZeroThrottle) {
+    constexpr double kSpinMin = 100.0;
+    EXPECT_DOUBLE_EQ(MAVLinkBridge::escToSpeed(0.0, 838.0, kSpinMin, 0.5), kSpinMin);
+    EXPECT_DOUBLE_EQ(MAVLinkBridge::escToSpeed(1.0, 838.0, kSpinMin, 0.5), 838.0);
+}
+
+TEST(ESCCurve, SpinMinOffsetScalesCorrectly) {
+    // With spin_min=100, max=838, exponent=1.0, throttle=0.5:
+    // ω = 100 + (838-100)*0.5 = 100 + 369 = 469
+    EXPECT_DOUBLE_EQ(MAVLinkBridge::escToSpeed(0.5, 838.0, 100.0, 1.0), 469.0);
+}


### PR DESCRIPTION
Closes #3.

## Summary

- Replaces the hardcoded linear throttle→speed mapping with a configurable power-law ESC curve: `ω = motor_spin_min + (max_motor_speed − motor_spin_min) × clamp(throttle,0,1)^esc_exponent`
- Default exponent is `0.5` (square-root), which makes thrust approximately linear in throttle — the standard model used by PX4/ArduPilot SITL. Setting `esc_exponent: 1.0` recovers the previous linear-speed behaviour.
- `motor_spin_min` (default `0.0`) adds support for an idle motor speed at zero throttle.
- Both parameters are added to `QuadrotorParams`, parsed from `config/default.json`, and wired through `BridgeParams` to `MAVLinkBridge`.
- The conversion is extracted to `MAVLinkBridge::escToSpeed` (public static) to allow unit testing without a live UDP socket.

## Test plan

- [x] 5 new `ESCCurve.*` tests in `tests/test_bridge.cpp` covering: linear mapping, sqrt (thrust-linear) mapping, boundary clamping, `motor_spin_min` at zero throttle, and `motor_spin_min` offset scaling.
- [x] All 24 tests pass (`ctest --output-on-failure`), zero build warnings.

🤖 Generated with [Claude Code](https://claude.ai/code)