### PR TITLE
feature(physics): upgrade Euler integration to RK4 in QuadrotorModel

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -14,7 +14,8 @@
     "inertia_diag": [0.029, 0.029, 0.055],
     "max_motor_speed": 838.0,
     "esc_exponent": 0.5,
-    "motor_spin_min": 0.0
+    "motor_spin_min": 0.0,
+    "use_rk4": true
   },
 
   "wind_params": {

--- a/include/simuav/ConfigLoader.inl
+++ b/include/simuav/ConfigLoader.inl
@@ -28,6 +28,7 @@ inline SimConfig loadConfig(const std::string& path) {
         p.max_motor_speed  = q.value("max_motor_speed", p.max_motor_speed);
         p.esc_exponent     = q.value("esc_exponent",    p.esc_exponent);
         p.motor_spin_min   = q.value("motor_spin_min",  p.motor_spin_min);
+        p.use_rk4          = q.value("use_rk4",         p.use_rk4);
         if (q.contains("inertia_diag") && q.at("inertia_diag").size() == 3) {
             auto& arr = q.at("inertia_diag");
             p.inertia_diag = {arr[0].get<double>(),

--- a/include/simuav/physics/QuadrotorModel.h
+++ b/include/simuav/physics/QuadrotorModel.h
@@ -31,6 +31,7 @@ struct QuadrotorParams {
     double max_motor_speed{838.0};  // rad/s (~8 000 RPM)
     double esc_exponent{0.5};       // throttle→speed power law: 0.5 = thrust-linear, 1.0 = speed-linear
     double motor_spin_min{0.0};     // rad/s — motor speed at zero throttle (idle)
+    bool   use_rk4{true};           // true = RK4 (default), false = semi-implicit Euler
 };
 
 // Full rigid-body state expressed in NED world frame.

--- a/src/physics/QuadrotorModel.cpp
+++ b/src/physics/QuadrotorModel.cpp
@@ -5,6 +5,14 @@ namespace simuav::physics {
 
 static constexpr double kGravity = 9.80665; // m/s²
 
+// State time-derivative used by the RK4 stepper (internal to this TU).
+struct Deriv {
+    Eigen::Vector3d vel;      // d(position)/dt
+    Eigen::Vector3d accel;    // d(velocity)/dt
+    Eigen::Vector4d dq;       // d(attitude.coeffs)/dt
+    Eigen::Vector3d domega;   // d(angular_velocity)/dt
+};
+
 QuadrotorModel::QuadrotorModel(QuadrotorParams params)
     : params_(std::move(params)) {}
 
@@ -75,24 +83,50 @@ void QuadrotorModel::integrate(const std::array<double, kNumMotors>& motor_speed
         w[i] = std::max(0.0, std::min(motor_speeds[i], params_.max_motor_speed));
     }
 
-    auto [lin_accel, ang_accel] = computeAccelerations(state_, w, wind_ned);
-    last_accel_world_ = lin_accel;
+    // Compute the full state derivative at state s.
+    auto deriv = [&](const State& s) -> Deriv {
+        auto [la, aa] = computeAccelerations(s, w, wind_ned);
+        const Eigen::Quaterniond oq(0.0, s.angular_velocity.x(),
+                                    s.angular_velocity.y(),
+                                    s.angular_velocity.z());
+        return {s.velocity, la, 0.5 * (s.attitude * oq).coeffs(), aa};
+    };
 
-    // Semi-implicit Euler integration
-    state_.velocity         += dt * lin_accel;
-    state_.position         += dt * state_.velocity;
-    state_.angular_velocity += dt * ang_accel;
+    // Advance a state by h * d without updating time.
+    auto advance = [](const State& s, const Deriv& d, double h) -> State {
+        State out = s;
+        out.position         += h * d.vel;
+        out.velocity         += h * d.accel;
+        out.attitude.coeffs() = (s.attitude.coeffs() + h * d.dq).normalized();
+        out.angular_velocity += h * d.domega;
+        return out;
+    };
 
-    // Quaternion kinematics: q_dot = 0.5 * q ⊗ [0, ω]
-    const Eigen::Quaterniond omega_quat(
-        0.0,
-        state_.angular_velocity.x(),
-        state_.angular_velocity.y(),
-        state_.angular_velocity.z()
-    );
-    const Eigen::Quaterniond dq = state_.attitude * omega_quat;
-    state_.attitude.coeffs() += 0.5 * dt * dq.coeffs();
-    state_.attitude.normalize();
+    if (params_.use_rk4) {
+        const Deriv k1 = deriv(state_);
+        const Deriv k2 = deriv(advance(state_, k1, 0.5 * dt));
+        const Deriv k3 = deriv(advance(state_, k2, 0.5 * dt));
+        const Deriv k4 = deriv(advance(state_, k3, dt));
+
+        last_accel_world_ = k1.accel;
+
+        const Deriv combined {
+            k1.vel    + 2.0*k2.vel    + 2.0*k3.vel    + k4.vel,
+            k1.accel  + 2.0*k2.accel  + 2.0*k3.accel  + k4.accel,
+            k1.dq     + 2.0*k2.dq     + 2.0*k3.dq     + k4.dq,
+            k1.domega + 2.0*k2.domega + 2.0*k3.domega + k4.domega,
+        };
+        state_ = advance(state_, combined, dt / 6.0);
+        state_.attitude.normalize();
+    } else {
+        // Semi-implicit Euler (legacy path — kept for benchmarking)
+        const Deriv d = deriv(state_);
+        last_accel_world_ = d.accel;
+        state_.velocity         += dt * d.accel;
+        state_.position         += dt * state_.velocity;  // semi-implicit: uses updated velocity
+        state_.angular_velocity += dt * d.domega;
+        state_.attitude.coeffs() = (state_.attitude.coeffs() + dt * d.dq).normalized();
+    }
 
     state_.time += dt;
 }

--- a/tests/test_physics.cpp
+++ b/tests/test_physics.cpp
@@ -62,6 +62,39 @@ TEST(QuadrotorModel, AttitudeQuaternionRemainsNormalised) {
     EXPECT_NEAR(model.state().attitude.norm(), 1.0, 1e-9);
 }
 
+TEST(QuadrotorModel, RK4IsMoreAccurateThanEulerInFreeFall) {
+    // With aero_drag = 0, free fall is dv/dt = g (constant), z(t) = 0.5*g*t^2.
+    // RK4 integrates degree-2 polynomials exactly; semi-implicit Euler accumulates O(dt) error.
+    static constexpr double kG  = 9.80665;
+    static constexpr double kT  = 10.0;
+    static constexpr double kDt = 0.004;
+    static constexpr int    kN  = static_cast<int>(kT / kDt);
+
+    const std::array<double, kNumMotors> motors{};
+
+    QuadrotorParams p_rk4;
+    p_rk4.use_rk4   = true;
+    p_rk4.aero_drag = 0.0;
+    QuadrotorModel rk4_model(p_rk4);
+
+    QuadrotorParams p_euler;
+    p_euler.use_rk4   = false;
+    p_euler.aero_drag = 0.0;
+    QuadrotorModel euler_model(p_euler);
+
+    for (int i = 0; i < kN; ++i) {
+        rk4_model.integrate(motors, kDt);
+        euler_model.integrate(motors, kDt);
+    }
+
+    const double z_exact     = 0.5 * kG * kT * kT;
+    const double rk4_error   = std::abs(rk4_model.state().position.z()  - z_exact);
+    const double euler_error = std::abs(euler_model.state().position.z() - z_exact);
+
+    EXPECT_LT(rk4_error,   1e-6);        // RK4 is exact for constant-force ODEs
+    EXPECT_LT(rk4_error,   euler_error); // RK4 beats Euler
+}
+
 TEST(WindModel, SampleReturnsFiniteVector) {
     WindModel wind;
     for (int i = 0; i < 100; ++i) {


### PR DESCRIPTION
Closes #4.

## Summary

- Replaces the semi-implicit Euler integrator with a 4th-order Runge-Kutta (RK4) stepper in `QuadrotorModel::integrate`
- The full state derivative is factored into a file-local `Deriv` struct (position, velocity, quaternion, angular velocity) and evaluated 4× per step
- The old Euler path is kept behind `QuadrotorParams::use_rk4 = false` for benchmarking — default is `true` (RK4)
- `use_rk4` is parsed from `config/default.json` via `ConfigLoader`

## Test plan

- [ ] All 25 existing tests still pass (`ctest`)
- [ ] New `QuadrotorModel.RK4IsMoreAccurateThanEulerInFreeFall`: runs 10 s drag-free free fall, asserts RK4 error < 1 µm (exact for constant-force ODEs) and RK4 error < Euler error