### PR TITLE
feature(physics): implement Dryden turbulence model in WindModel

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -20,9 +20,17 @@
 
   "wind_params": {
     "mean_ned": [0.0, 0.0, 0.0],
-    "turbulence_std": 0.5,
     "gust_probability": 0.005,
-    "gust_magnitude": 3.0
+    "gust_magnitude": 3.0,
+    "use_dryden": true,
+    "turbulence_std": 0.5,
+    "dryden_airspeed": 15.0,
+    "dryden_length_u": 200.0,
+    "dryden_length_v": 200.0,
+    "dryden_length_w": 50.0,
+    "dryden_sigma_u": 1.5,
+    "dryden_sigma_v": 1.5,
+    "dryden_sigma_w": 0.75
   },
 
   "imu_params": {

--- a/include/simuav/ConfigLoader.inl
+++ b/include/simuav/ConfigLoader.inl
@@ -40,9 +40,17 @@ inline SimConfig loadConfig(const std::string& path) {
     if (j.contains("wind_params")) {
         const auto& w  = j.at("wind_params");
         auto& p        = cfg.wind_params;
-        p.turbulence_std   = w.value("turbulence_std",   p.turbulence_std);
-        p.gust_probability = w.value("gust_probability", p.gust_probability);
-        p.gust_magnitude   = w.value("gust_magnitude",   p.gust_magnitude);
+        p.gust_probability  = w.value("gust_probability",  p.gust_probability);
+        p.gust_magnitude    = w.value("gust_magnitude",    p.gust_magnitude);
+        p.use_dryden        = w.value("use_dryden",        p.use_dryden);
+        p.turbulence_std    = w.value("turbulence_std",    p.turbulence_std);
+        p.dryden_airspeed   = w.value("dryden_airspeed",  p.dryden_airspeed);
+        p.dryden_length_u   = w.value("dryden_length_u",  p.dryden_length_u);
+        p.dryden_length_v   = w.value("dryden_length_v",  p.dryden_length_v);
+        p.dryden_length_w   = w.value("dryden_length_w",  p.dryden_length_w);
+        p.dryden_sigma_u    = w.value("dryden_sigma_u",   p.dryden_sigma_u);
+        p.dryden_sigma_v    = w.value("dryden_sigma_v",   p.dryden_sigma_v);
+        p.dryden_sigma_w    = w.value("dryden_sigma_w",   p.dryden_sigma_w);
         if (w.contains("mean_ned") && w.at("mean_ned").size() == 3) {
             auto& arr = w.at("mean_ned");
             p.mean_ned = {arr[0].get<double>(),

--- a/include/simuav/physics/WindModel.h
+++ b/include/simuav/physics/WindModel.h
@@ -5,27 +5,65 @@
 namespace simuav::physics {
 
 struct WindParams {
-    Eigen::Vector3d mean_ned{Eigen::Vector3d::Zero()}; // m/s, steady component
-    double turbulence_std{0.5};   // m/s, white-noise turbulence per axis
+    // --- Steady wind + gusts (always active) ---
+    Eigen::Vector3d mean_ned{Eigen::Vector3d::Zero()}; // m/s, constant mean
     double gust_probability{0.005}; // probability per step of a discrete gust
-    double gust_magnitude{3.0};   // m/s, peak gust speed
+    double gust_magnitude{3.0};     // m/s, peak gust speed
+
+    // --- Turbulence mode ---
+    // use_dryden = true : Dryden frequency-shaped turbulence (MIL-HDBK-1797)
+    // use_dryden = false: white-noise turbulence (legacy)
+    bool   use_dryden{true};
+    double turbulence_std{0.5};     // m/s, white-noise std (use_dryden = false only)
+
+    // --- Dryden parameters (use_dryden = true) ---
+    double dryden_airspeed{15.0};   // m/s, equivalent airspeed
+    double dryden_length_u{200.0};  // m, scale length for N/u component
+    double dryden_length_v{200.0};  // m, scale length for E/v component
+    double dryden_length_w{50.0};   // m, scale length for D/w component
+    double dryden_sigma_u{1.5};     // m/s, turbulence intensity, N/u
+    double dryden_sigma_v{1.5};     // m/s, turbulence intensity, E/v
+    double dryden_sigma_w{0.75};    // m/s, turbulence intensity, D/w
 };
 
 // Produces a wind velocity vector in NED each simulation step.
-// Models: constant mean + white-noise turbulence + random discrete gusts.
+// Models: constant mean + Dryden (or white-noise) turbulence + random discrete gusts.
+//
+// Dryden shaping filters (MIL-HDBK-1797):
+//   u/N (1st-order AR):  H_u(s) = σ·√(2τ/π) / (1 + τ·s),  τ = L/V
+//   v/E, w/D (2nd-order): H(s)  = σ·√(τ/π) · (1 + √3·τ·s) / (1 + τ·s)²
 class WindModel {
 public:
-    explicit WindModel(WindParams params = {}, uint64_t seed = 0);
+    explicit WindModel(WindParams params = {}, double dt = 0.004, uint64_t seed = 0);
 
     // Call once per physics step. Returns wind velocity in NED (m/s).
     Eigen::Vector3d sample();
 
 private:
+    Eigen::Vector3d drydenSample();
+
     WindParams params_;
+    double dt_;
+
+    // Gust state
     Eigen::Vector3d current_gust_{Eigen::Vector3d::Zero()};
+
+    // Dryden state
+    double          dry_xu_{0.0};                        // AR(1) state, u/N
+    Eigen::Vector2d dry_xv_{Eigen::Vector2d::Zero()};    // 2-state, v/E
+    Eigen::Vector2d dry_xw_{Eigen::Vector2d::Zero()};    // 2-state, w/D
+
+    // Precomputed Dryden coefficients
+    double dry_au_{0.0}, dry_bu_{0.0};       // AR(1): x = a·x + b·ξ
+    double dry_tau_v_{1.0};                  // τ_v = L_v/V
+    double dry_out_v1_{0.0}, dry_out_v2_{0.0}; // output weights for xv
+    double dry_tau_w_{1.0};
+    double dry_out_w1_{0.0}, dry_out_w2_{0.0};
+    double dry_noise_vw_{0.0};               // √(π·dt): noise gain for v/w states
+
     std::mt19937_64 rng_;
-    std::normal_distribution<double>  normal_{0.0, 1.0};
-    std::uniform_real_distribution<double> uniform_{0.0, 1.0};
+    std::normal_distribution<double>           normal_{0.0, 1.0};
+    std::uniform_real_distribution<double>     uniform_{0.0, 1.0};
 };
 
 }  // namespace simuav::physics

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -9,7 +9,7 @@ namespace simuav {
 Simulator::Simulator(SimConfig config)
     : config_(std::move(config))
     , model_(config_.quad_params)
-    , wind_(config_.wind_params)
+    , wind_(config_.wind_params, config_.dt)
     , imu_(config_.imu_params)
     , gps_(config_.gps_params)
     , baro_(config_.baro_params)

--- a/src/physics/WindModel.cpp
+++ b/src/physics/WindModel.cpp
@@ -41,13 +41,13 @@ Eigen::Vector3d WindModel::drydenSample() {
     dry_xu_ = dry_au_ * dry_xu_ + dry_bu_ * normal_(rng_);
 
     // v/E and w/D: 2-state Euler  (ẋ₁ = x₂,  ẋ₂ = −x₁/τ² − 2x₂/τ + w)
-    auto step2 = [&](Eigen::Vector2d& x, double tau) {
+    auto advanceFilter = [&](Eigen::Vector2d& x, double tau) {
         const double x2dot = -(x[0] / (tau * tau)) - (2.0 * x[1] / tau);
         x[0] += dt_ * x[1];
         x[1] += dt_ * x2dot + dry_noise_vw_ * normal_(rng_);
     };
-    step2(dry_xv_, dry_tau_v_);
-    step2(dry_xw_, dry_tau_w_);
+    advanceFilter(dry_xv_, dry_tau_v_);
+    advanceFilter(dry_xw_, dry_tau_w_);
 
     return {
         dry_xu_,

--- a/src/physics/WindModel.cpp
+++ b/src/physics/WindModel.cpp
@@ -1,26 +1,89 @@
 #include "simuav/physics/WindModel.h"
+#include <cmath>
 
 namespace simuav::physics {
 
-WindModel::WindModel(WindParams params, uint64_t seed)
-    : params_(std::move(params)), rng_(seed) {}
+WindModel::WindModel(WindParams params, double dt, uint64_t seed)
+    : params_(std::move(params)), dt_(dt), rng_(seed)
+{
+    if (!params_.use_dryden) return;
+
+    const double V = params_.dryden_airspeed;
+
+    // --- u/N: 1st-order AR(1) ---
+    // Exact discretisation preserving variance σ_u²: x = a·x + b·ξ
+    const double tau_u = params_.dryden_length_u / V;
+    dry_au_ = std::exp(-dt_ / tau_u);
+    dry_bu_ = params_.dryden_sigma_u * std::sqrt(1.0 - dry_au_ * dry_au_);
+
+    // --- v/E: 2-state Euler (controllable canonical form) ---
+    // Continuous: ẋ = A·x + B·w(t),  w ~ N(0, π) per unit time
+    //   A = [[0, 1], [-1/τ², -2/τ]],  B = [0, 1]ᵀ
+    //   y = K·[1/τ², √3/τ]·x,  K = σ·√(τ/π)
+    // Output variance = σ²  (verified via Lyapunov equation)
+    dry_tau_v_   = params_.dryden_length_v / V;
+    const double Kv   = params_.dryden_sigma_v * std::sqrt(dry_tau_v_ / M_PI);
+    dry_out_v1_  = Kv / (dry_tau_v_ * dry_tau_v_);
+    dry_out_v2_  = Kv * std::sqrt(3.0) / dry_tau_v_;
+
+    // --- w/D: same form as v ---
+    dry_tau_w_   = params_.dryden_length_w / V;
+    const double Kw   = params_.dryden_sigma_w * std::sqrt(dry_tau_w_ / M_PI);
+    dry_out_w1_  = Kw / (dry_tau_w_ * dry_tau_w_);
+    dry_out_w2_  = Kw * std::sqrt(3.0) / dry_tau_w_;
+
+    // Shared noise gain for both 2nd-order filters: √(π·dt)
+    dry_noise_vw_ = std::sqrt(M_PI * dt_);
+}
+
+Eigen::Vector3d WindModel::drydenSample() {
+    // --- u/N: AR(1) ---
+    dry_xu_ = dry_au_ * dry_xu_ + dry_bu_ * normal_(rng_);
+
+    // --- v/E: 2-state Euler step ---
+    // x1_dot = x2,  x2_dot = -x1/τ² - 2x2/τ + w(t)
+    {
+        const double x1 = dry_xv_[0];
+        const double x2 = dry_xv_[1];
+        dry_xv_[0] = x1 + dt_ * x2;
+        dry_xv_[1] = x2 + dt_ * (-x1 / (dry_tau_v_ * dry_tau_v_)
+                                  - 2.0 * x2 / dry_tau_v_)
+                       + dry_noise_vw_ * normal_(rng_);
+    }
+
+    // --- w/D: 2-state Euler step ---
+    {
+        const double x1 = dry_xw_[0];
+        const double x2 = dry_xw_[1];
+        dry_xw_[0] = x1 + dt_ * x2;
+        dry_xw_[1] = x2 + dt_ * (-x1 / (dry_tau_w_ * dry_tau_w_)
+                                  - 2.0 * x2 / dry_tau_w_)
+                       + dry_noise_vw_ * normal_(rng_);
+    }
+
+    return {
+        dry_xu_,
+        dry_out_v1_ * dry_xv_[0] + dry_out_v2_ * dry_xv_[1],
+        dry_out_w1_ * dry_xw_[0] + dry_out_w2_ * dry_xw_[1]
+    };
+}
 
 Eigen::Vector3d WindModel::sample() {
-    // Turbulence: independent white noise per axis
-    Eigen::Vector3d turbulence(
-        params_.turbulence_std * normal_(rng_),
-        params_.turbulence_std * normal_(rng_),
-        params_.turbulence_std * normal_(rng_)
-    );
+    // Turbulence
+    const Eigen::Vector3d turbulence = params_.use_dryden
+        ? drydenSample()
+        : Eigen::Vector3d{
+              params_.turbulence_std * normal_(rng_),
+              params_.turbulence_std * normal_(rng_),
+              params_.turbulence_std * normal_(rng_)};
 
-    // Discrete gust: random direction, fixed magnitude, decays over ~20 steps
+    // Discrete gust: random horizontal direction, exponential decay
     if (uniform_(rng_) < params_.gust_probability) {
         Eigen::Vector3d dir(normal_(rng_), normal_(rng_), 0.0);
-        if (dir.norm() > 1e-6) {
+        if (dir.norm() > 1e-6)
             current_gust_ = params_.gust_magnitude * dir.normalized();
-        }
     }
-    current_gust_ *= 0.95; // exponential decay
+    current_gust_ *= 0.95;
 
     return params_.mean_ned + turbulence + current_gust_;
 }

--- a/src/physics/WindModel.cpp
+++ b/src/physics/WindModel.cpp
@@ -37,29 +37,17 @@ WindModel::WindModel(WindParams params, double dt, uint64_t seed)
 }
 
 Eigen::Vector3d WindModel::drydenSample() {
-    // --- u/N: AR(1) ---
+    // u/N: exact AR(1) — x = a·x + b·ξ
     dry_xu_ = dry_au_ * dry_xu_ + dry_bu_ * normal_(rng_);
 
-    // --- v/E: 2-state Euler step ---
-    // x1_dot = x2,  x2_dot = -x1/τ² - 2x2/τ + w(t)
-    {
-        const double x1 = dry_xv_[0];
-        const double x2 = dry_xv_[1];
-        dry_xv_[0] = x1 + dt_ * x2;
-        dry_xv_[1] = x2 + dt_ * (-x1 / (dry_tau_v_ * dry_tau_v_)
-                                  - 2.0 * x2 / dry_tau_v_)
-                       + dry_noise_vw_ * normal_(rng_);
-    }
-
-    // --- w/D: 2-state Euler step ---
-    {
-        const double x1 = dry_xw_[0];
-        const double x2 = dry_xw_[1];
-        dry_xw_[0] = x1 + dt_ * x2;
-        dry_xw_[1] = x2 + dt_ * (-x1 / (dry_tau_w_ * dry_tau_w_)
-                                  - 2.0 * x2 / dry_tau_w_)
-                       + dry_noise_vw_ * normal_(rng_);
-    }
+    // v/E and w/D: 2-state Euler  (ẋ₁ = x₂,  ẋ₂ = −x₁/τ² − 2x₂/τ + w)
+    auto step2 = [&](Eigen::Vector2d& x, double tau) {
+        const double x2dot = -(x[0] / (tau * tau)) - (2.0 * x[1] / tau);
+        x[0] += dt_ * x[1];
+        x[1] += dt_ * x2dot + dry_noise_vw_ * normal_(rng_);
+    };
+    step2(dry_xv_, dry_tau_v_);
+    step2(dry_xw_, dry_tau_w_);
 
     return {
         dry_xu_,

--- a/tests/test_physics.cpp
+++ b/tests/test_physics.cpp
@@ -102,3 +102,57 @@ TEST(WindModel, SampleReturnsFiniteVector) {
         EXPECT_TRUE(w.allFinite());
     }
 }
+
+TEST(WindModel, DrydenVarianceMatchesSigma) {
+    // Use high airspeed so τ = L/V is small (τ_u=τ_v=1s, τ_w=0.25s), giving
+    // ~200+ decorrelation times in the collection window for reliable variance estimation.
+    static constexpr double kDt       = 0.004;
+    static constexpr int    kWarmup   = static_cast<int>(10.0 / kDt);  // 10 s (10× τ_v)
+    static constexpr int    kCollect  = static_cast<int>(200.0 / kDt); // 200 s
+
+    WindParams p;
+    p.use_dryden       = true;
+    p.dryden_airspeed  = 200.0;   // m/s — high V → short τ → fast decorrelation
+    p.dryden_length_u  = 200.0;   // τ_u = 1.0 s
+    p.dryden_length_v  = 200.0;   // τ_v = 1.0 s
+    p.dryden_length_w  = 50.0;    // τ_w = 0.25 s
+    p.dryden_sigma_u   = 1.5;
+    p.dryden_sigma_v   = 1.5;
+    p.dryden_sigma_w   = 0.75;
+    p.gust_probability = 0.0;
+    WindModel wind(p, kDt, /*seed=*/42);
+
+    for (int i = 0; i < kWarmup; ++i) wind.sample();
+
+    Eigen::Vector3d sum  = Eigen::Vector3d::Zero();
+    Eigen::Vector3d sum2 = Eigen::Vector3d::Zero();
+    for (int i = 0; i < kCollect; ++i) {
+        const Eigen::Vector3d s = wind.sample();
+        sum  += s;
+        sum2 += s.cwiseProduct(s);
+    }
+    const Eigen::Vector3d mean = sum / kCollect;
+    const Eigen::Vector3d var  = sum2 / kCollect - mean.cwiseProduct(mean);
+
+    EXPECT_NEAR(var[0], p.dryden_sigma_u * p.dryden_sigma_u, 0.2 * p.dryden_sigma_u * p.dryden_sigma_u);
+    EXPECT_NEAR(var[1], p.dryden_sigma_v * p.dryden_sigma_v, 0.2 * p.dryden_sigma_v * p.dryden_sigma_v);
+    EXPECT_NEAR(var[2], p.dryden_sigma_w * p.dryden_sigma_w, 0.2 * p.dryden_sigma_w * p.dryden_sigma_w);
+}
+
+TEST(WindModel, WhiteNoiseFallbackWorks) {
+    WindParams p;
+    p.use_dryden    = false;
+    p.turbulence_std = 2.0;
+    p.gust_probability = 0.0;
+    WindModel wind(p, 0.004, /*seed=*/7);
+
+    static constexpr int kN = 50000;
+    double sum2 = 0.0;
+    for (int i = 0; i < kN; ++i) {
+        const double u = wind.sample()[0];
+        sum2 += u * u;
+    }
+    const double empirical_var = sum2 / kN;
+    EXPECT_NEAR(empirical_var, p.turbulence_std * p.turbulence_std,
+                0.1 * p.turbulence_std * p.turbulence_std);
+}


### PR DESCRIPTION
Closes #5.

## Summary

- Replaces flat white-noise turbulence with MIL-HDBK-1797 Dryden frequency-shaped filters
- **u/N (1st-order):** exact AR(1) — coefficient `a = exp(-dt/τ)`, noise `b = σ√(1-a²)`, output variance = σ² by construction
- **v/E, w/D (2nd-order):** 2-state Euler system driven by noise with gain `√(π·dt)`; output variance converges to σ² in the continuous limit (Lyapunov equation: `P = [[πτ³/4, 0],[0, πτ/4]]`, `C·P·Cᵀ = σ²`)
- White-noise fallback (`use_dryden = false`) preserved
- `WindModel` constructor gains a `dt` parameter for coefficient pre-computation; `Simulator` passes `config_.dt`
- All Dryden parameters (`airspeed`, `length_u/v/w`, `sigma_u/v/w`) exposed in `config/default.json` and parsed by `ConfigLoader`

## Test plan

- [ ] All 27 existing tests pass (`ctest`)
- [ ] `DrydenVarianceMatchesSigma`: runs at V=200 m/s (τ≈1 s, ~200 decorrelation times) and verifies each axis variance is within 20% of σ²
- [ ] `WhiteNoiseFallbackWorks`: verifies the legacy white-noise path still produces correct variance