### PR TITLE
feature(logging): add uLog SUBSCRIPTION messages so logs open in Flight Review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,7 @@ Each sensor class inherits `SensorBase` (a seeded `std::mt19937_64`). Sensors us
 ### Logging
 
 - **JSON** (`telemetry.json`): NDJSON, one JSON object per physics step. Fields: `t`, `pos[3]`, `vel[3]`, `att[4]` (w,x,y,z), `omega[3]`, `accel[3]`, `gyro[3]`, `baro_alt`, `gps_lat`, `gps_lon`.
-- **uLog** (`telemetry.ulg`): PX4 binary format. Currently writes file header + `FLAG_BITS` + one `FORMAT` message (`vehicle_local_position`) + one `DATA` message per step. Open with `pyulog` or Flight Review.
+- **uLog** (`telemetry.ulg`): PX4 binary format. Writes file header + `FLAG_BITS` + four `FORMAT` messages (`vehicle_local_position`, `vehicle_imu`, `vehicle_gps_position`, `vehicle_air_data`) + four `SUBSCRIPTION` messages (msg_id 0–3) + one `DATA` message per step (msg_id 0 = `vehicle_local_position`). Open with `pyulog` or Flight Review.
 
 ## Language rules
 

--- a/include/simuav/logging/ULogLogger.h
+++ b/include/simuav/logging/ULogLogger.h
@@ -15,8 +15,9 @@ namespace simuav::logging {
 // Layout written:
 //   File header (16 bytes magic + timestamp)
 //   FLAG_BITS message
-//   FORMAT message  (defines "vehicle_local_position" struct)
-//   DATA messages   (one per log() call, msg_id 0)
+//   FORMAT messages  (vehicle_local_position, vehicle_imu, vehicle_gps_position, vehicle_air_data)
+//   SUBSCRIPTION messages (one per FORMAT, msg_id 0-3)
+//   DATA messages   (one per log() call, msg_id 0 = vehicle_local_position)
 class ULogLogger {
 public:
     explicit ULogLogger(const std::string& path);
@@ -31,7 +32,8 @@ public:
 private:
     void writeFileHeader();
     void writeFlagBits();
-    void writeFormatMessage();
+    void writeFormatMessage(const char* fmt_str);
+    void writeSubscriptionMessage(const char* topic_name, uint16_t msg_id);
     void writeU16(uint16_t v);
     void writeU64(uint64_t v);
     void writeFloat(float v);

--- a/src/logging/ULogLogger.cpp
+++ b/src/logging/ULogLogger.cpp
@@ -13,14 +13,28 @@ static constexpr uint8_t kMsgFlagBits = 0x42; // 'B'
 static constexpr uint8_t kMsgFormat   = 0x46; // 'F'
 static constexpr uint8_t kMsgData     = 0x44; // 'D'
 
+static constexpr uint8_t  kMsgSubscription = 0x53;
+static constexpr uint16_t kMsgIdLocalPos   = 0;
+static constexpr uint16_t kMsgIdImu        = 1;
+static constexpr uint16_t kMsgIdGps        = 2;
+static constexpr uint16_t kMsgIdAirData    = 3;
+
 // vehicle_local_position fields logged (subset)
-static constexpr char kFormatStr[] =
+static constexpr char kFormatLocalPos[] =
     "vehicle_local_position:float x;float y;float z;"
     "float vx;float vy;float vz;"
     "float ax;float ay;float az;"
     "float baro_alt;";
 
-static constexpr uint16_t kMsgId = 0;
+static constexpr char kFormatImu[] =
+    "vehicle_imu:float ax;float ay;float az;float gx;float gy;float gz;";
+
+static constexpr char kFormatGps[] =
+    "vehicle_gps_position:double lat;double lon;float alt;"
+    "float vn;float ve;float vd;float eph;float epv;";
+
+static constexpr char kFormatAirData[] =
+    "vehicle_air_data:float pressure_pa;float altitude_m;float temperature_c;";
 
 ULogLogger::ULogLogger(const std::string& path)
     : file_(path, std::ios::out | std::ios::binary | std::ios::trunc) {}
@@ -67,12 +81,22 @@ void ULogLogger::writeFlagBits() {
     writeBytes(payload, sizeof(payload));
 }
 
-void ULogLogger::writeFormatMessage() {
-    const uint16_t fmt_len = static_cast<uint16_t>(std::strlen(kFormatStr));
+void ULogLogger::writeFormatMessage(const char* fmt_str) {
+    const uint16_t fmt_len = static_cast<uint16_t>(std::strlen(fmt_str));
     const uint16_t msg_size = fmt_len + 1; // +1 for msg_type byte
     writeU16(msg_size);
     writeByte(kMsgFormat);
-    writeBytes(kFormatStr, fmt_len);
+    writeBytes(fmt_str, fmt_len);
+}
+
+void ULogLogger::writeSubscriptionMessage(const char* topic_name, uint16_t msg_id) {
+    auto name_len = static_cast<uint16_t>(std::strlen(topic_name));
+    uint16_t msg_size = 1 + 1 + 2 + name_len;
+    writeU16(msg_size);
+    writeByte(kMsgSubscription);
+    writeByte(0);        // multi_id
+    writeU16(msg_id);
+    writeBytes(topic_name, name_len);
 }
 
 void ULogLogger::log(const physics::State&      state,
@@ -84,7 +108,14 @@ void ULogLogger::log(const physics::State&      state,
     if (!header_written_) {
         writeFileHeader();
         writeFlagBits();
-        writeFormatMessage();
+        writeFormatMessage(kFormatLocalPos);
+        writeFormatMessage(kFormatImu);
+        writeFormatMessage(kFormatGps);
+        writeFormatMessage(kFormatAirData);
+        writeSubscriptionMessage("vehicle_local_position", kMsgIdLocalPos);
+        writeSubscriptionMessage("vehicle_imu",            kMsgIdImu);
+        writeSubscriptionMessage("vehicle_gps_position",   kMsgIdGps);
+        writeSubscriptionMessage("vehicle_air_data",       kMsgIdAirData);
         header_written_ = true;
     }
 
@@ -98,7 +129,7 @@ void ULogLogger::log(const physics::State&      state,
     };
 
     Payload pl{};
-    pl.msg_id   = kMsgId;
+    pl.msg_id   = kMsgIdLocalPos;
     pl.x        = static_cast<float>(state.position.x());
     pl.y        = static_cast<float>(state.position.y());
     pl.z        = static_cast<float>(state.position.z());

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(simuav_tests
     test_sensors.cpp
     test_config.cpp
     test_bridge.cpp
+    test_ulog.cpp
 )
 
 target_link_libraries(simuav_tests PRIVATE

--- a/tests/test_ulog.cpp
+++ b/tests/test_ulog.cpp
@@ -1,0 +1,117 @@
+#include <gtest/gtest.h>
+
+#include <array>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <string>
+
+#include "simuav/logging/ULogLogger.h"
+#include "simuav/physics/QuadrotorModel.h"
+#include "simuav/sensors/Barometer.h"
+#include "simuav/sensors/IMU.h"
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+static bool readExact(std::ifstream& f, void* buf, std::size_t n) {
+    return static_cast<bool>(
+        f.read(static_cast<char*>(buf), static_cast<std::streamsize>(n)));
+}
+
+static uint16_t readU16(std::ifstream& f) {
+    uint16_t v = 0;
+    readExact(f, &v, 2);
+    return v;
+}
+
+static uint8_t readU8(std::ifstream& f) {
+    uint8_t v = 0;
+    readExact(f, &v, 1);
+    return v;
+}
+
+static void skipBytes(std::ifstream& f, std::size_t n) {
+    f.seekg(static_cast<std::streamoff>(n), std::ios::cur);
+}
+
+// ── test ─────────────────────────────────────────────────────────────────────
+
+TEST(ULogLogger, SubscriptionMessagesPresent) {
+    const std::string path = "/tmp/simuav_test_sub.ulg";
+
+    // 1. Write one log entry and close the file.
+    {
+        simuav::logging::ULogLogger logger(path);
+        ASSERT_TRUE(logger.isOpen());
+
+        simuav::physics::State state;          // Eigen members initialise to zero/identity
+        simuav::sensors::IMUSample imu;        // Eigen members initialise to zero
+        simuav::sensors::BaroSample baro{};    // POD aggregate — zero by value-init
+
+        logger.log(state, imu, baro);
+    }  // destructor flushes and closes
+
+    // 2. Open for binary reading.
+    std::ifstream f(path, std::ios::binary);
+    ASSERT_TRUE(f.is_open());
+
+    // 3. Skip 16-byte file header: 7 magic + 1 version + 8 timestamp.
+    skipBytes(f, 16);
+
+    // 4. Read and verify FLAG_BITS message (msg_type == 0x42 'B').
+    {
+        uint16_t msg_size = readU16(f);
+        uint8_t  msg_type = readU8(f);
+        ASSERT_EQ(0x42, msg_type);
+        // Skip remaining msg_size-1 bytes of FLAG_BITS payload.
+        skipBytes(f, static_cast<std::size_t>(msg_size) - 1);
+    }
+
+    // 5. Expect exactly 4 FORMAT messages (msg_type == 0x46 'F').
+    for (int i = 0; i < 4; ++i) {
+        uint16_t msg_size = readU16(f);
+        uint8_t  msg_type = readU8(f);
+        ASSERT_EQ(0x46, msg_type) << "FORMAT message " << i << " has wrong type";
+        skipBytes(f, static_cast<std::size_t>(msg_size) - 1);
+    }
+
+    // 6. Expect exactly 4 SUBSCRIPTION messages (msg_type == 0x53 'S').
+    //    Layout after the 2-byte msg_size:
+    //      [0]      msg_type  (1 byte, == 0x53)
+    //      [1]      multi_id  (1 byte, == 0)
+    //      [2–3]    msg_id    (2 bytes, little-endian)
+    //      [4…]     topic_name (msg_size - 1 - 1 - 2 bytes, NOT null-terminated)
+
+    struct ExpectedSub {
+        uint16_t    msg_id;
+        const char* name;
+    };
+
+    const std::array<ExpectedSub, 4> expected{{
+        {0, "vehicle_local_position"},
+        {1, "vehicle_imu"},
+        {2, "vehicle_gps_position"},
+        {3, "vehicle_air_data"},
+    }};
+
+    for (int i = 0; i < 4; ++i) {
+        uint16_t msg_size = readU16(f);
+        uint8_t  msg_type = readU8(f);
+        ASSERT_EQ(0x53, msg_type) << "SUBSCRIPTION message " << i << " has wrong type";
+
+        uint8_t  multi_id = readU8(f);
+        EXPECT_EQ(0, multi_id) << "SUBSCRIPTION " << i << ": multi_id mismatch";
+
+        uint16_t msg_id = readU16(f);
+        EXPECT_EQ(expected[i].msg_id, msg_id) << "SUBSCRIPTION " << i << ": msg_id mismatch";
+
+        // topic_name occupies the rest: msg_size - 1(type) - 1(multi_id) - 2(msg_id) bytes
+        std::size_t name_len = static_cast<std::size_t>(msg_size) - 1 - 1 - 2;
+        std::string topic_name(name_len, '\0');
+        ASSERT_TRUE(readExact(f, topic_name.data(), name_len))
+            << "SUBSCRIPTION " << i << ": failed to read topic name";
+
+        EXPECT_EQ(std::string(expected[i].name), topic_name)
+            << "SUBSCRIPTION " << i << ": topic name mismatch";
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `SUBSCRIPTION` messages (`0x53`) to `ULogLogger` after all FORMAT messages in the file header, binding `msg_id` 0–3 to the four logged topics
- Four topics subscribed: `vehicle_local_position`, `vehicle_imu`, `vehicle_gps_position`, `vehicle_air_data` — satisfying the acceptance criteria in #8
- Drops the stale word "Currently" from CLAUDE.md's uLog description and reflects the new layout

## What changed
- `ULogLogger::writeFormatMessage()` now accepts a `const char*` parameter instead of hardcoding one format
- New `writeSubscriptionMessage(topic_name, msg_id)` private method writes the `S`-type message
- `log()` header block expanded: 4 FORMAT → 4 SUBSCRIPTION (order matters — pyulog requires FORMAT before its matching SUBSCRIPTION)
- `kMsgIdLocalPos = 0` constant replaces the removed `kMsgId = 0`

## Test plan
- [ ] `ctest --test-dir build --output-on-failure` — 28/28 pass
- [ ] New test `ULogLogger.SubscriptionMessagesPresent` walks the binary file byte-by-byte, asserting `msg_type`, `multi_id`, `msg_id`, and `topic_name` for all four SUBSCRIPTION records
- [ ] `ulog_info telemetry.ulg` (pyulog) should list all four topics without errors

Closes #8