### PR TITLE
feature(logging): add --replay flag to feed JSON logs through sensor pipeline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,7 +107,8 @@ Each sensor class inherits `SensorBase` (a seeded `std::mt19937_64`). Sensors us
 ### Logging
 
 - **JSON** (`telemetry.json`): NDJSON, one JSON object per physics step. Fields: `t`, `pos[3]`, `vel[3]`, `att[4]` (w,x,y,z), `omega[3]`, `accel[3]`, `gyro[3]`, `baro_alt`, `gps_lat`, `gps_lon`.
-- **uLog** (`telemetry.ulg`): PX4 binary format. Currently writes file header + `FLAG_BITS` + one `FORMAT` message (`vehicle_local_position`) + one `DATA` message per step. Open with `pyulog` or Flight Review.
+- **uLog** (`telemetry.ulg`): PX4 binary format. Writes file header + `FLAG_BITS` + four `FORMAT` messages (`vehicle_local_position`, `vehicle_imu`, `vehicle_gps_position`, `vehicle_air_data`) + four `SUBSCRIPTION` messages (msg_id 0–3) + one `DATA` message per step (msg_id 0 = `vehicle_local_position`). Open with `pyulog` or Flight Review.
+- **Replay** (`--replay <path>`): reads an NDJSON log, reconstructs `physics::State` from each entry, derives `accel_world` by finite-differencing consecutive velocity entries, and feeds the states through the sensor pipeline without connecting to firmware. See `include/simuav/LogReplayer.h`.
 
 ## Language rules
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(simuav_lib STATIC
     src/logging/JSONLogger.cpp
     src/logging/ULogLogger.cpp
     src/Simulator.cpp
+    src/LogReplayer.cpp
 )
 
 target_include_directories(simuav_lib PUBLIC

--- a/include/simuav/LogReplayer.h
+++ b/include/simuav/LogReplayer.h
@@ -1,0 +1,44 @@
+#pragma once
+#include "simuav/physics/QuadrotorModel.h"
+#include "simuav/sensors/IMU.h"
+#include "simuav/sensors/GPS.h"
+#include "simuav/sensors/Barometer.h"
+#include "simuav/sensors/Magnetometer.h"
+
+#include <Eigen/Dense>
+#include <string>
+#include <vector>
+
+namespace simuav {
+
+struct ReplayEntry {
+    physics::State  state;
+    // World-frame linear acceleration (NED, m/s²), finite-differenced from
+    // consecutive velocity entries. Zero for the first entry (no predecessor).
+    Eigen::Vector3d accel_world{Eigen::Vector3d::Zero()};
+};
+
+struct ReplaySamples {
+    sensors::IMUSample  imu;
+    sensors::BaroSample baro;
+    sensors::MagSample  mag;
+    sensors::GPSSample  gps;
+    bool                gps_valid{false};
+};
+
+// Parses an NDJSON telemetry file (as written by JSONLogger) into a vector of
+// ReplayEntry. Throws std::runtime_error on I/O or parse failure.
+// accel_world for entry[0] is Zero() — logs starting mid-flight should treat
+// the first entry's IMU output as unreliable.
+[[nodiscard]] std::vector<ReplayEntry> loadLog(const std::string& path);
+
+// Drives one replay step: feeds entry through the four sensor models and
+// returns all samples. GPS::sample() may return false (rate-throttled); gps_out
+// is unchanged in that case (ReplaySamples::gps_valid == false).
+ReplaySamples replayStep(const ReplayEntry&      entry,
+                         sensors::IMU&           imu,
+                         sensors::GPS&           gps,
+                         sensors::Barometer&     baro,
+                         sensors::Magnetometer&  mag);
+
+}  // namespace simuav

--- a/src/LogReplayer.cpp
+++ b/src/LogReplayer.cpp
@@ -1,0 +1,71 @@
+#include "simuav/LogReplayer.h"
+
+#include <nlohmann/json.hpp>
+
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+namespace simuav {
+
+std::vector<ReplayEntry> loadLog(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open())
+        throw std::runtime_error("loadLog: cannot open '" + path + "'");
+
+    std::vector<ReplayEntry> entries;
+    std::string line;
+
+    while (std::getline(f, line)) {
+        if (line.empty()) continue;
+
+        const nlohmann::json j = nlohmann::json::parse(line);
+
+        ReplayEntry e;
+        e.state.time = j.at("t").get<double>();
+
+        const auto& pos = j.at("pos");
+        e.state.position = {pos[0].get<double>(), pos[1].get<double>(), pos[2].get<double>()};
+
+        const auto& vel = j.at("vel");
+        e.state.velocity = {vel[0].get<double>(), vel[1].get<double>(), vel[2].get<double>()};
+
+        const auto& att = j.at("att");
+        e.state.attitude = Eigen::Quaterniond(
+            att[0].get<double>(), att[1].get<double>(),
+            att[2].get<double>(), att[3].get<double>());
+
+        const auto& omega = j.at("omega");
+        e.state.angular_velocity = {
+            omega[0].get<double>(), omega[1].get<double>(), omega[2].get<double>()};
+
+        entries.push_back(std::move(e));
+    }
+
+    // Compute accel_world via finite difference of consecutive velocity entries.
+    // Entry 0 keeps the default Zero() — no predecessor available.
+    for (std::size_t i = 1; i < entries.size(); ++i) {
+        const double dt = entries[i].state.time - entries[i - 1].state.time;
+        if (dt > 0.0)
+            entries[i].accel_world =
+                (entries[i].state.velocity - entries[i - 1].state.velocity) / dt;
+    }
+
+    return entries;
+}
+
+ReplaySamples replayStep(const ReplayEntry&      entry,
+                         sensors::IMU&           imu,
+                         sensors::GPS&           gps,
+                         sensors::Barometer&     baro,
+                         sensors::Magnetometer&  mag)
+{
+    ReplaySamples out;
+    out.imu       = imu.sample(entry.state, entry.accel_world);
+    out.baro      = baro.sample(entry.state);
+    out.mag       = mag.sample(entry.state);
+    out.gps_valid = gps.sample(entry.state, out.gps);
+    return out;
+}
+
+}  // namespace simuav

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,12 +1,15 @@
 // simuav
 #include "simuav/Simulator.h"
 #include "simuav/ConfigLoader.h"
+#include "simuav/LogReplayer.h"
 
 // std
 #include <csignal>
 #include <cstdlib>
 #include <cstdio>
+#include <chrono>
 #include <string>
+#include <thread>
 
 namespace {
 simuav::Simulator* g_sim = nullptr;
@@ -17,16 +20,23 @@ void onSignal(int) {
 } // namespace
 
 int main(int argc, char* argv[]) {
-    // Resolve config path: --config <path> > config/default.json > hardcoded defaults
     std::string config_path;
+    std::string replay_path;
+
     for (int i = 1; i < argc; ++i) {
-        if (std::string(argv[i]) == "--config") {
+        const std::string arg(argv[i]);
+        if (arg == "--config") {
             if (i + 1 >= argc) {
                 std::fprintf(stderr, "--config requires a path argument\n");
                 return EXIT_FAILURE;
             }
-            config_path = argv[i + 1];
-            break;
+            config_path = argv[++i];
+        } else if (arg == "--replay") {
+            if (i + 1 >= argc) {
+                std::fprintf(stderr, "--replay requires a path argument\n");
+                return EXIT_FAILURE;
+            }
+            replay_path = argv[++i];
         }
     }
 
@@ -42,6 +52,40 @@ int main(int argc, char* argv[]) {
         }
     } else {
         cfg = simuav::tryLoadConfig("config/default.json");
+    }
+
+    if (!replay_path.empty()) {
+        std::vector<simuav::ReplayEntry> entries;
+        try {
+            entries = simuav::loadLog(replay_path);
+        } catch (const std::exception& e) {
+            std::fprintf(stderr, "Error loading log '%s': %s\n",
+                         replay_path.c_str(), e.what());
+            return EXIT_FAILURE;
+        }
+
+        std::printf("Replay mode: %zu entries from %s\n",
+                    entries.size(), replay_path.c_str());
+
+        simuav::sensors::IMU          imu(cfg.imu_params);
+        simuav::sensors::GPS          gps(cfg.gps_params);
+        simuav::sensors::Barometer    baro(cfg.baro_params);
+        simuav::sensors::Magnetometer mag(cfg.mag_params);
+
+        for (std::size_t i = 0; i < entries.size(); ++i) {
+            simuav::replayStep(entries[i], imu, gps, baro, mag);
+
+            if (i + 1 < entries.size()) {
+                const double delta_s = entries[i + 1].state.time - entries[i].state.time;
+                if (delta_s > 0.0) {
+                    std::this_thread::sleep_for(
+                        std::chrono::duration<double>(delta_s));
+                }
+            }
+        }
+
+        std::printf("Replay complete.\n");
+        return EXIT_SUCCESS;
     }
 
     simuav::Simulator sim(cfg);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable(simuav_tests
     test_sensors.cpp
     test_config.cpp
     test_bridge.cpp
+    test_replay.cpp
 )
 
 target_link_libraries(simuav_tests PRIVATE

--- a/tests/test_replay.cpp
+++ b/tests/test_replay.cpp
@@ -1,0 +1,154 @@
+#include <gtest/gtest.h>
+
+#include "simuav/LogReplayer.h"
+#include "simuav/sensors/Barometer.h"
+#include "simuav/sensors/GPS.h"
+#include "simuav/sensors/IMU.h"
+#include "simuav/sensors/Magnetometer.h"
+
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+#include <string>
+
+namespace {
+
+static constexpr double kDt      = 0.004;
+static constexpr int    kSteps   = 250;
+static constexpr double kGravity = 9.80665;
+static const std::string kFixture = "/tmp/simuav_replay_test.ndjson";
+
+// Writes kSteps NDJSON lines for a free-fall trajectory starting from rest.
+// Only pos/vel/att/omega/t are used by the replayer; the sensor fields are
+// placeholders that satisfy the JSON schema but are not read back.
+void writeFixture() {
+    std::ofstream f(kFixture);
+    f << std::fixed << std::setprecision(6);
+    for (int i = 0; i < kSteps; ++i) {
+        const double t  = (i + 1) * kDt;
+        const double vz = kGravity * t;
+        const double pz = 0.5 * kGravity * t * t;
+        f << "{\"t\":"    << t
+          << ",\"pos\":["  << "0.000000,0.000000," << pz << ']'
+          << ",\"vel\":["  << "0.000000,0.000000," << vz << ']'
+          << ",\"att\":[1.000000,0.000000,0.000000,0.000000]"
+          << ",\"omega\":[0.000000,0.000000,0.000000]"
+          << ",\"accel\":[0.000000,0.000000,0.000000]"
+          << ",\"gyro\":[0.000000,0.000000,0.000000]"
+          << ",\"baro_alt\":488.000000"
+          << ",\"gps_lat\":" << std::setprecision(9) << 47.397742000
+          << ",\"gps_lon\":" << 8.545594000
+          << "}\n";
+        f << std::setprecision(6);
+    }
+}
+
+// Returns sensor param sets with all noise and bias zeroed for deterministic tests.
+simuav::sensors::IMUParams zeroIMU() {
+    simuav::sensors::IMUParams p;
+    p.accel_noise_std = 0.0;
+    p.accel_bias_std  = 0.0;
+    p.gyro_noise_std  = 0.0;
+    p.gyro_bias_std   = 0.0;
+    return p;
+}
+
+simuav::sensors::GPSParams zeroGPS(double rate_hz = 5.0) {
+    simuav::sensors::GPSParams p;
+    p.pos_noise_std_m = 0.0;
+    p.alt_noise_std_m = 0.0;
+    p.vel_noise_std   = 0.0;
+    p.update_rate_hz  = rate_hz;
+    return p;
+}
+
+simuav::sensors::BaroParams zeroBaro() {
+    simuav::sensors::BaroParams p;
+    p.noise_std_m = 0.0;
+    return p;
+}
+
+simuav::sensors::MagParams zeroMag() {
+    simuav::sensors::MagParams p;
+    p.noise_std = 0.0;
+    return p;
+}
+
+} // namespace
+
+class ReplayIntegration : public ::testing::Test {
+protected:
+    void SetUp() override { writeFixture(); }
+};
+
+TEST_F(ReplayIntegration, LoadLogParsesAllEntries) {
+    const auto entries = simuav::loadLog(kFixture);
+    ASSERT_EQ(static_cast<int>(entries.size()), kSteps);
+
+    // First entry: no predecessor → accel_world must be Zero
+    EXPECT_NEAR(entries[0].accel_world.norm(), 0.0, 1e-12);
+    EXPECT_DOUBLE_EQ(entries[0].state.time, kDt);
+
+    // Second entry onwards: finite-diff should recover gravity in NED z.
+    // 6-decimal-place velocity truncation gives ~1.5e-4 m/s² quantisation error.
+    EXPECT_NEAR(entries[1].accel_world.x(), 0.0,      1e-3);
+    EXPECT_NEAR(entries[1].accel_world.y(), 0.0,      1e-3);
+    EXPECT_NEAR(entries[1].accel_world.z(), kGravity, 2e-4);
+}
+
+TEST_F(ReplayIntegration, ReplayedIMUMatchesFreeFall) {
+    const auto entries = simuav::loadLog(kFixture);
+
+    simuav::sensors::IMU          imu(zeroIMU());
+    simuav::sensors::GPS          gps(zeroGPS());
+    simuav::sensors::Barometer    baro(zeroBaro());
+    simuav::sensors::Magnetometer mag(zeroMag());
+
+    // In free fall, specific force = accel_world - gravity = 0 → all three axes
+    // are zero for every entry after the first (where accel_world is recovered).
+    for (int i = 1; i < kSteps; ++i) {
+        const auto s = simuav::replayStep(entries[i], imu, gps, baro, mag);
+        EXPECT_NEAR(s.imu.accel_body.x(), 0.0, 1e-3) << "step " << i;
+        EXPECT_NEAR(s.imu.accel_body.y(), 0.0, 1e-3) << "step " << i;
+        EXPECT_NEAR(s.imu.accel_body.z(), 0.0, 1e-3) << "step " << i;
+        EXPECT_NEAR(s.imu.gyro_body.x(),  0.0, 1e-9) << "step " << i;
+        EXPECT_NEAR(s.imu.gyro_body.y(),  0.0, 1e-9) << "step " << i;
+        EXPECT_NEAR(s.imu.gyro_body.z(),  0.0, 1e-9) << "step " << i;
+    }
+}
+
+TEST_F(ReplayIntegration, ReplayedBaroTracksAltitude) {
+    const auto entries = simuav::loadLog(kFixture);
+
+    simuav::sensors::IMU          imu(zeroIMU());
+    simuav::sensors::GPS          gps(zeroGPS());
+    simuav::sensors::Barometer    baro(zeroBaro());
+    simuav::sensors::Magnetometer mag(zeroMag());
+
+    for (int i = 0; i < kSteps; ++i) {
+        const auto s = simuav::replayStep(entries[i], imu, gps, baro, mag);
+        const double t            = (i + 1) * kDt;
+        const double expected_alt = 488.0 - 0.5 * kGravity * t * t;
+        EXPECT_NEAR(static_cast<double>(s.baro.altitude_m), expected_alt, 1e-3)
+            << "step " << i;
+    }
+}
+
+TEST_F(ReplayIntegration, ReplayedGPSMatchesReferenceOrigin) {
+    const auto entries = simuav::loadLog(kFixture);
+
+    // Drive GPS at 1000 Hz (interval < dt) so every step produces a fix,
+    // avoiding floating-point boundary issues at update_rate_hz == 250 Hz.
+    simuav::sensors::IMU          imu(zeroIMU());
+    simuav::sensors::GPS          gps(zeroGPS(1000.0));
+    simuav::sensors::Barometer    baro(zeroBaro());
+    simuav::sensors::Magnetometer mag(zeroMag());
+
+    // North/East position is zero throughout → lat/lon must equal reference exactly
+    for (int i = 0; i < kSteps; ++i) {
+        const auto s = simuav::replayStep(entries[i], imu, gps, baro, mag);
+        ASSERT_TRUE(s.gps_valid) << "expected GPS fix at step " << i;
+        EXPECT_NEAR(s.gps.latitude_deg,  47.397742, 2e-7) << "step " << i;
+        EXPECT_NEAR(s.gps.longitude_deg,  8.545594, 2e-7) << "step " << i;
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `loadLog()` + `replayStep()` in a new `LogReplayer` class compiled into `simuav_lib`
- `./simuav --replay telemetry.json` runs the full sensor pipeline offline without connecting to firmware
- World-frame acceleration recovered via finite-differencing consecutive velocity entries

## Test plan
- [x] `ReplayIntegration.LoadLogParsesAllEntries` — parses 250 entries, verifies accel_world finite-diff
- [x] `ReplayIntegration.ReplayedIMUMatchesFreeFall` — zero specific force in free fall
- [x] `ReplayIntegration.ReplayedBaroTracksAltitude` — deterministic ISA formula
- [x] `ReplayIntegration.ReplayedGPSMatchesReferenceOrigin` — lat/lon at reference when pos=[0,0,*]
- [x] All 31 tests passing

Closes #9