### PR TITLE
feature(comms): add ArduPilot MAVLink dialect support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,9 +93,10 @@ Thrust in body: `[0, 0, −F_total]` (upward = negative body-Z).
 ### MAVLink bridge
 
 - **Outbound**: `HIL_SENSOR` every physics step (250 Hz); `HIL_GPS` at `gps_params.update_rate_hz` (default 5 Hz).
-- **Inbound**: `HIL_ACTUATOR_CONTROLS` — normalized `[0, 1]` per motor, linearly mapped to `[0, max_motor_speed]` rad/s.
+- **Inbound**: `HIL_ACTUATOR_CONTROLS` (normalized [0,1], PX4 and ArduPilot) or `RC_CHANNELS_OVERRIDE` (PWM [1000–2000 µs], ArduPilot SITL only). Motor channels 1–4 map to motor indices 0–3.
 - Socket is **non-blocking** (`O_NONBLOCK`). If no packet arrives in a step, the previous motor command is reused.
 - Default ports: simulator binds `14561`, sends to firmware at `14560` (PX4 SITL default).
+- Firmware target is selected via `"firmware_target": "px4"` or `"firmware_target": "ardupilot"` in the config file (default: `"px4"`). The `ardupilotmega` MAVLink dialect header (a strict superset of `common`) is always included.
 
 ### Sensor noise model
 
@@ -114,7 +115,7 @@ Each sensor class inherits `SensorBase` (a seeded `std::mt19937_64`). Sensors us
 - C++17 strict: no C++20 features. Nested namespaces (`namespace a::b`) and structured bindings (`auto [x, y]`) are fine.
 - `-Wall -Wextra -Wpedantic -Werror` are enforced by CMake — zero warnings allowed.
 - All public headers live under `include/simuav/` and are included as `#include "simuav/..."`
-- MAVLink headers are included as `#include "common/mavlink.h"` (the dialect subdirectory is on the include path).
+- MAVLink headers are included as `#include "ardupilotmega/mavlink.h"` (the dialect subdirectory is on the include path). This is a strict superset of `common`; all common message IDs remain unchanged.
 
 ## Key files for new contributors
 

--- a/config/default.json
+++ b/config/default.json
@@ -2,6 +2,7 @@
   "dt": 0.004,
   "mavlink_host": "127.0.0.1",
   "mavlink_port": 14560,
+  "firmware_target": "px4",
   "json_log_path": "telemetry.json",
   "ulog_path": "telemetry.ulg",
 

--- a/include/simuav/ConfigLoader.inl
+++ b/include/simuav/ConfigLoader.inl
@@ -17,6 +17,12 @@ inline SimConfig loadConfig(const std::string& path) {
     cfg.json_log_path  = j.value("json_log_path",  cfg.json_log_path);
     cfg.ulog_path      = j.value("ulog_path",      cfg.ulog_path);
 
+    {
+        const std::string ft = j.value("firmware_target", std::string("px4"));
+        cfg.firmware_target = (ft == "ardupilot") ? FirmwareTarget::ArduPilot
+                                                   : FirmwareTarget::PX4;
+    }
+
     if (j.contains("quad_params")) {
         const auto& q      = j.at("quad_params");
         auto& p            = cfg.quad_params;

--- a/include/simuav/FirmwareTarget.h
+++ b/include/simuav/FirmwareTarget.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <cstdint>
+
+namespace simuav {
+
+enum class FirmwareTarget : uint8_t {
+    PX4       = 0,
+    ArduPilot = 1,
+};
+
+}  // namespace simuav

--- a/include/simuav/Simulator.h
+++ b/include/simuav/Simulator.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "simuav/FirmwareTarget.h"
 #include "simuav/physics/QuadrotorModel.h"
 #include "simuav/physics/WindModel.h"
 #include "simuav/sensors/IMU.h"
@@ -15,9 +16,10 @@
 namespace simuav {
 
 struct SimConfig {
-    double      dt{0.004};                  // s, physics timestep (250 Hz)
-    std::string mavlink_host{"127.0.0.1"};
-    uint16_t    mavlink_port{14560};
+    double         dt{0.004};                  // s, physics timestep (250 Hz)
+    std::string    mavlink_host{"127.0.0.1"};
+    uint16_t       mavlink_port{14560};
+    FirmwareTarget firmware_target{FirmwareTarget::PX4};
     std::string json_log_path{"telemetry.json"};
     std::string ulog_path{"telemetry.ulg"};
 

--- a/include/simuav/comms/MAVLinkBridge.h
+++ b/include/simuav/comms/MAVLinkBridge.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "simuav/FirmwareTarget.h"
 #include "simuav/sensors/IMU.h"
 #include "simuav/sensors/GPS.h"
 #include "simuav/sensors/Barometer.h"
@@ -8,20 +9,23 @@
 #include <string>
 #include <cstdint>
 
-// MAVLink common dialect (C headers from mavlink/c_library_v2)
-#include "common/mavlink.h"
+// ardupilotmega is a strict superset of common; including it here gives
+// access to all common HIL messages plus ArduPilot-specific ones (e.g.
+// RC_CHANNELS_OVERRIDE used by ArduPilot SITL to send actuator commands).
+#include "ardupilotmega/mavlink.h"
 
 namespace simuav::comms {
 
 struct BridgeParams {
-    std::string remote_host{"127.0.0.1"}; // firmware address
-    uint16_t    remote_port{14560};       // firmware listens here (PX4 default)
-    uint16_t    local_port{14561};        // we bind here
-    uint8_t     system_id{1};
-    uint8_t     component_id{MAV_COMP_ID_AUTOPILOT1};
-    double      max_motor_speed{838.0};   // rad/s — must match QuadrotorParams
-    double      esc_exponent{0.5};        // power-law exponent for throttle→speed curve
-    double      motor_spin_min{0.0};      // rad/s — idle speed at zero throttle
+    std::string    remote_host{"127.0.0.1"}; // firmware address
+    uint16_t       remote_port{14560};       // firmware listens here (PX4 default)
+    uint16_t       local_port{14561};        // we bind here
+    uint8_t        system_id{1};
+    uint8_t        component_id{MAV_COMP_ID_AUTOPILOT1};
+    double         max_motor_speed{838.0};   // rad/s — must match QuadrotorParams
+    double         esc_exponent{0.5};        // power-law exponent for throttle→speed curve
+    double         motor_spin_min{0.0};      // rad/s — idle speed at zero throttle
+    FirmwareTarget firmware_target{FirmwareTarget::PX4};
 };
 
 // Non-blocking UDP bridge between the simulator and drone firmware.
@@ -31,7 +35,8 @@ struct BridgeParams {
 //   HIL_GPS      – position + velocity     (at GPS update rate)
 //
 // Inbound (firmware → sim):
-//   HIL_ACTUATOR_CONTROLS – motor PWM outputs → converted to rad/s
+//   HIL_ACTUATOR_CONTROLS  – normalised [0,1] per motor (PX4 and ArduPilot)
+//   RC_CHANNELS_OVERRIDE   – PWM [1000–2000 µs] per channel (ArduPilot SITL)
 class MAVLinkBridge {
 public:
     explicit MAVLinkBridge(BridgeParams params = {});

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -21,6 +21,7 @@ Simulator::Simulator(SimConfig config)
         bp.max_motor_speed = config_.quad_params.max_motor_speed;
         bp.esc_exponent    = config_.quad_params.esc_exponent;
         bp.motor_spin_min  = config_.quad_params.motor_spin_min;
+        bp.firmware_target = config_.firmware_target;
         return bp;
     }())
     , json_log_(config_.json_log_path)

--- a/src/comms/MAVLinkBridge.cpp
+++ b/src/comms/MAVLinkBridge.cpp
@@ -147,9 +147,31 @@ bool MAVLinkBridge::receiveActuators(std::array<double, 4>& out_speeds) {
                 mavlink_hil_actuator_controls_t act{};
                 mavlink_msg_hil_actuator_controls_decode(&msg, &act);
 
-                for (int i = 0; i < 4; ++i) {
-                    out_speeds[i] = escToSpeed(
-                        static_cast<double>(act.controls[i]),
+                for (int k = 0; k < 4; ++k) {
+                    out_speeds[k] = escToSpeed(
+                        static_cast<double>(act.controls[k]),
+                        params_.max_motor_speed,
+                        params_.motor_spin_min,
+                        params_.esc_exponent);
+                }
+                got_actuators = true;
+            }
+
+            // ArduPilot SITL sends RC_CHANNELS_OVERRIDE with PWM values
+            // [1000–2000 µs] on channels 1–4 for the four motors.
+            if (params_.firmware_target == FirmwareTarget::ArduPilot &&
+                msg.msgid == MAVLINK_MSG_ID_RC_CHANNELS_OVERRIDE) {
+                mavlink_rc_channels_override_t rc{};
+                mavlink_msg_rc_channels_override_decode(&msg, &rc);
+
+                const uint16_t chans[4] = {
+                    rc.chan1_raw, rc.chan2_raw, rc.chan3_raw, rc.chan4_raw
+                };
+                for (int k = 0; k < 4; ++k) {
+                    const double throttle =
+                        (static_cast<double>(chans[k]) - 1000.0) / 1000.0;
+                    out_speeds[k] = escToSpeed(
+                        throttle,
                         params_.max_motor_speed,
                         params_.motor_spin_min,
                         params_.esc_exponent);

--- a/tests/test_bridge.cpp
+++ b/tests/test_bridge.cpp
@@ -36,3 +36,38 @@ TEST(ESCCurve, SpinMinOffsetScalesCorrectly) {
     // ω = 100 + (838-100)*0.5 = 100 + 369 = 469
     EXPECT_DOUBLE_EQ(MAVLinkBridge::escToSpeed(0.5, 838.0, 100.0, 1.0), 469.0);
 }
+
+// ── Dialect: message ID regressions ──────────────────────────────────────────
+//
+// These tests pin the compile-time MAVLink constants that both firmware targets
+// depend on. Switching the dialect header (ardupilotmega vs common) must not
+// change any of these IDs.
+
+TEST(MavLinkDialect, Px4HilMessageIds) {
+    // Pack a HIL_SENSOR and confirm the resulting msgid matches the constant.
+    mavlink_message_t msg{};
+    mavlink_msg_hil_sensor_pack(1, 1, &msg,
+        0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0);
+    EXPECT_EQ(msg.msgid, static_cast<uint32_t>(MAVLINK_MSG_ID_HIL_SENSOR));
+    EXPECT_EQ(static_cast<uint32_t>(MAVLINK_MSG_ID_HIL_SENSOR),           107u);
+    EXPECT_EQ(static_cast<uint32_t>(MAVLINK_MSG_ID_HIL_GPS),              113u);
+    EXPECT_EQ(static_cast<uint32_t>(MAVLINK_MSG_ID_HIL_ACTUATOR_CONTROLS), 93u);
+}
+
+TEST(MavLinkDialect, ArduPilotRcChannelsOverrideId) {
+    EXPECT_EQ(static_cast<uint32_t>(MAVLINK_MSG_ID_RC_CHANNELS_OVERRIDE), 70u);
+}
+
+TEST(MavLinkDialect, ArduPilotPwmNormalisation) {
+    // 1000 µs → throttle 0.0, 1500 µs → 0.5, 2000 µs → 1.0
+    auto pwmToSpeed = [](uint16_t pwm) {
+        const double t = (static_cast<double>(pwm) - 1000.0) / 1000.0;
+        return MAVLinkBridge::escToSpeed(t, 838.0, 0.0, 1.0);
+    };
+    EXPECT_DOUBLE_EQ(pwmToSpeed(1000),   0.0);
+    EXPECT_DOUBLE_EQ(pwmToSpeed(1500), 419.0);
+    EXPECT_DOUBLE_EQ(pwmToSpeed(2000), 838.0);
+    // Values outside [1000,2000] clamp to [0,1] throttle range
+    EXPECT_DOUBLE_EQ(pwmToSpeed(500),    0.0);
+    EXPECT_DOUBLE_EQ(pwmToSpeed(3000), 838.0);
+}


### PR DESCRIPTION
## Summary
- Adds `FirmwareTarget` enum (`PX4` | `ArduPilot`) to `SimConfig` and `BridgeParams`
- Config key `"firmware_target": "px4"` (default) or `"firmware_target": "ardupilot"`
- Switches MAVLink include to `ardupilotmega/mavlink.h` (strict superset of common — no breaking changes)
- In ArduPilot mode, `receiveActuators()` also accepts `RC_CHANNELS_OVERRIDE` (msg_id 70) with PWM [1000–2000 µs] on channels 1–4

## Test plan
- [x] `MavLinkDialect.Px4HilMessageIds` — pins HIL_SENSOR=107, HIL_GPS=113, HIL_ACTUATOR_CONTROLS=93
- [x] `MavLinkDialect.ArduPilotRcChannelsOverrideId` — pins RC_CHANNELS_OVERRIDE=70
- [x] `MavLinkDialect.ArduPilotPwmNormalisation` — 1000/1500/2000 µs → 0/419/838 rad/s
- [x] All existing ESCCurve and other tests unaffected — 30/30 passing

Closes #11