### PR TITLE
fix(ci): correct PX4 requirements.txt path from root to Tools/setup/

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -82,11 +82,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: pip-venv-${{ hashFiles('px4-autopilot/requirements.txt') }}
+          key: pip-venv-${{ hashFiles('px4-autopilot/Tools/setup/requirements.txt') }}
           restore-keys: pip-venv-
 
       - name: Install PX4 Python requirements
-        run: .venv/bin/pip install --upgrade pip -r px4-autopilot/requirements.txt
+        run: .venv/bin/pip install --upgrade pip -r px4-autopilot/Tools/setup/requirements.txt
 
       - name: Install pymavlink
         run: .venv/bin/pip install pymavlink


### PR DESCRIPTION
## Root cause

`px4-autopilot/requirements.txt` does not exist in PX4 v1.14. The file lives at `Tools/setup/requirements.txt`. Two consequences:
- `hashFiles('px4-autopilot/requirements.txt')` returned an empty string, so the pip venv cache key was always `pip-venv-` (never a hit after invalidation)
- `.venv/bin/pip install … -r px4-autopilot/requirements.txt` failed immediately with `No such file or directory`

Both the 2026-04-30 and 2026-05-01 nightly runs failed at "Install PX4 Python requirements".

## Fix

Two-line change: both the `hashFiles` expression and the `pip install -r` path updated to `px4-autopilot/Tools/setup/requirements.txt`.

## Test plan
- [ ] Nightly e2e job reaches "Run E2E test" step without error
- [ ] Pip venv cache key is non-empty on subsequent runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)