### PR TITLE
fix(comms): correct HIL_SENSOR fields_updated bitmask (exclude DIFF_PRESSURE, include TEMPERATURE)

### DIFF
--- a/src/comms/MAVLinkBridge.cpp
+++ b/src/comms/MAVLinkBridge.cpp
@@ -73,8 +73,22 @@ void MAVLinkBridge::sendHilSensor(const sensors::IMUSample&  imu,
     mavlink_message_t msg{};
     const uint64_t time_us = static_cast<uint64_t>(imu.timestamp * 1e6);
 
-    // fields_updated bitmask: accel(0-2) + gyro(3-5) + mag(6-8) + baro(9-11)
-    constexpr uint32_t kAllSensors = 0b111111111111u;
+    // fields_updated: every field we populate, using the typed enum from common.h.
+    // DIFF_PRESSURE is excluded (not modelled — field is 0.0f).
+    // TEMPERATURE is included (populated from the barometer ISA model).
+    constexpr uint32_t kAllSensors =
+        HIL_SENSOR_UPDATED_XACC        |
+        HIL_SENSOR_UPDATED_YACC        |
+        HIL_SENSOR_UPDATED_ZACC        |
+        HIL_SENSOR_UPDATED_XGYRO       |
+        HIL_SENSOR_UPDATED_YGYRO       |
+        HIL_SENSOR_UPDATED_ZGYRO       |
+        HIL_SENSOR_UPDATED_XMAG        |
+        HIL_SENSOR_UPDATED_YMAG        |
+        HIL_SENSOR_UPDATED_ZMAG        |
+        HIL_SENSOR_UPDATED_ABS_PRESSURE |
+        HIL_SENSOR_UPDATED_PRESSURE_ALT |
+        HIL_SENSOR_UPDATED_TEMPERATURE;
 
     mavlink_msg_hil_sensor_pack(
         params_.system_id, params_.component_id, &msg,

--- a/tests/test_bridge.cpp
+++ b/tests/test_bridge.cpp
@@ -58,6 +58,40 @@ TEST(MavLinkDialect, ArduPilotRcChannelsOverrideId) {
     EXPECT_EQ(static_cast<uint32_t>(MAVLINK_MSG_ID_RC_CHANNELS_OVERRIDE), 70u);
 }
 
+// ── HIL_SENSOR fields_updated bitmask ────────────────────────────────────────
+//
+// Regression test for the bitmask used in MAVLinkBridge::sendHilSensor.
+// The old value (0b111111111111 = 4095) set DIFF_PRESSURE (bit 10) and
+// cleared TEMPERATURE (bit 12). The corrected symbolic constant must invert
+// that: DIFF_PRESSURE clear, TEMPERATURE set.
+
+TEST(HilSensorBitmask, CorrectBitmaskValue) {
+    constexpr uint32_t kCorrect =
+        HIL_SENSOR_UPDATED_XACC         |
+        HIL_SENSOR_UPDATED_YACC         |
+        HIL_SENSOR_UPDATED_ZACC         |
+        HIL_SENSOR_UPDATED_XGYRO        |
+        HIL_SENSOR_UPDATED_YGYRO        |
+        HIL_SENSOR_UPDATED_ZGYRO        |
+        HIL_SENSOR_UPDATED_XMAG         |
+        HIL_SENSOR_UPDATED_YMAG         |
+        HIL_SENSOR_UPDATED_ZMAG         |
+        HIL_SENSOR_UPDATED_ABS_PRESSURE |
+        HIL_SENSOR_UPDATED_PRESSURE_ALT |
+        HIL_SENSOR_UPDATED_TEMPERATURE;
+
+    EXPECT_EQ(kCorrect, 7167u);  // 1+2+4+8+16+32+64+128+256+512+2048+4096
+
+    EXPECT_NE(kCorrect & HIL_SENSOR_UPDATED_TEMPERATURE,   0u) << "TEMPERATURE bit must be set";
+    EXPECT_EQ(kCorrect & HIL_SENSOR_UPDATED_DIFF_PRESSURE, 0u) << "DIFF_PRESSURE bit must be clear";
+}
+
+TEST(HilSensorBitmask, OldBitmaskWasWrong) {
+    constexpr uint32_t kOld = 0b111111111111u; // 4095 — the pre-fix value
+    EXPECT_NE(kOld & HIL_SENSOR_UPDATED_DIFF_PRESSURE, 0u) << "old value incorrectly set DIFF_PRESSURE";
+    EXPECT_EQ(kOld & HIL_SENSOR_UPDATED_TEMPERATURE,   0u) << "old value incorrectly cleared TEMPERATURE";
+}
+
 TEST(MavLinkDialect, ArduPilotPwmNormalisation) {
     // 1000 µs → throttle 0.0, 1500 µs → 0.5, 2000 µs → 1.0
     auto pwmToSpeed = [](uint16_t pwm) {


### PR DESCRIPTION
## Summary

- Replaces the raw literal `0b111111111111u` (4095) in `MAVLinkBridge::sendHilSensor` with the correct symbolic OR of `HIL_SENSOR_UPDATED_FLAGS` enum values
- The old value set `DIFF_PRESSURE` (bit 10 = 1024, field is always `0.0f`) and cleared `TEMPERATURE` (bit 12 = 4096) — causing PX4 to fuse a spurious zero airspeed every step and ignore temperature
- New value is 7167 (`0x1BFF`): all populated sensor fields, no diff pressure

## Test plan

- [ ] `HilSensorBitmask.CorrectBitmaskValue`: asserts new constant equals 7167, TEMPERATURE bit set, DIFF_PRESSURE bit clear
- [ ] `HilSensorBitmask.OldBitmaskWasWrong`: documents why the old literal was wrong (DIFF_PRESSURE set, TEMPERATURE clear)
- [ ] Full suite: 49/49 tests pass

Closes #47