### PR TITLE
fix(sensors): derive Barometer temperature from ISA lapse rate instead of fixed 20°C

### DIFF
--- a/config/ardupilot_sitl.json
+++ b/config/ardupilot_sitl.json
@@ -60,7 +60,7 @@
   "baro_params": {
     "alt_ref_m": 488.0,
     "noise_std_m": 0.3,
-    "temperature_c": 20.0
+    "ground_temp_offset_c": 0.0
   },
 
   "mag_params": {

--- a/config/default.json
+++ b/config/default.json
@@ -60,7 +60,7 @@
   "baro_params": {
     "alt_ref_m": 488.0,
     "noise_std_m": 0.3,
-    "temperature_c": 20.0
+    "ground_temp_offset_c": 0.0
   },
 
   "mag_params": {

--- a/include/simuav/ConfigLoader.inl
+++ b/include/simuav/ConfigLoader.inl
@@ -95,9 +95,9 @@ inline SimConfig loadConfig(const std::string& path) {
     if (j.contains("baro_params")) {
         const auto& b  = j.at("baro_params");
         auto& p        = cfg.baro_params;
-        p.alt_ref_m     = b.value("alt_ref_m",     p.alt_ref_m);
-        p.noise_std_m   = b.value("noise_std_m",   p.noise_std_m);
-        p.temperature_c = b.value("temperature_c", p.temperature_c);
+        p.alt_ref_m            = b.value("alt_ref_m",            p.alt_ref_m);
+        p.noise_std_m          = b.value("noise_std_m",          p.noise_std_m);
+        p.ground_temp_offset_c = b.value("ground_temp_offset_c", p.ground_temp_offset_c);
     }
 
     if (j.contains("mag_params")) {

--- a/include/simuav/sensors/Barometer.h
+++ b/include/simuav/sensors/Barometer.h
@@ -5,9 +5,9 @@
 namespace simuav::sensors {
 
 struct BaroParams {
-    double alt_ref_m{488.0};         // MSL altitude of reference origin
-    double noise_std_m{0.3};         // m equivalent altitude noise
-    double temperature_c{20.0};      // ambient temperature (currently fixed)
+    double alt_ref_m{488.0};              // MSL altitude of reference origin
+    double noise_std_m{0.3};             // m equivalent altitude noise
+    double ground_temp_offset_c{0.0};    // non-standard day offset added to ISA temperature (°C)
 };
 
 struct BaroSample {

--- a/src/sensors/Barometer.cpp
+++ b/src/sensors/Barometer.cpp
@@ -15,11 +15,15 @@ BaroSample Barometer::sample(const physics::State& state) {
     const double exponent = (kG * kM) / (kR * kL);
     const double pressure = kP0 * std::pow(1.0 - (kL * altitude_msl) / kT0, exponent);
 
+    // ISA temperature at altitude, plus optional non-standard day offset.
+    const double temperature_c = (kT0 - kL * altitude_msl) - 273.15
+                                  + params_.ground_temp_offset_c;
+
     BaroSample out;
-    out.timestamp    = state.time;
-    out.pressure_pa  = static_cast<float>(pressure);
-    out.altitude_m   = static_cast<float>(altitude_msl);
-    out.temperature_c = static_cast<float>(params_.temperature_c);
+    out.timestamp     = state.time;
+    out.pressure_pa   = static_cast<float>(pressure);
+    out.altitude_m    = static_cast<float>(altitude_msl);
+    out.temperature_c = static_cast<float>(temperature_c);
     return out;
 }
 

--- a/tests/test_sensors.cpp
+++ b/tests/test_sensors.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <cmath>
 #include "simuav/sensors/IMU.h"
 #include "simuav/sensors/GPS.h"
 #include "simuav/sensors/Barometer.h"
@@ -106,6 +107,51 @@ TEST(Barometer, PressureDecreasesWithAltitude) {
     const auto low  = baro.sample(s_low);
     const auto high = baro.sample(s_high);
     EXPECT_LT(high.pressure_pa, low.pressure_pa);
+}
+
+TEST(Barometer, TemperatureDecreasesWithAltitude) {
+    sensors::BaroParams p;
+    p.alt_ref_m   = 0.0;
+    p.noise_std_m = 0.0;
+    sensors::Barometer baro(p);
+
+    physics::State s_sea  = makeHoverState(); s_sea.position.z()  =    0.0;  // 0 m
+    physics::State s_high = makeHoverState(); s_high.position.z() = -5000.0; // 5000 m up
+
+    const auto sea  = baro.sample(s_sea);
+    const auto high = baro.sample(s_high);
+
+    EXPECT_LT(high.temperature_c, sea.temperature_c) << "temperature must decrease with altitude";
+
+    // ISA at 5000 m: T = 288.15 - 0.0065*5000 = 255.65 K = -17.5 °C
+    EXPECT_NEAR(high.temperature_c, -17.5f, 0.1f) << "temperature at 5000 m must match ISA";
+}
+
+TEST(Barometer, TemperatureConsistentWithPressure) {
+    // Back-calculate altitude from the returned pressure using the ISA formula
+    // and verify it matches altitude_m to within 1 m.
+    static constexpr double kP0 = 101325.0;
+    static constexpr double kT0 = 288.15;
+    static constexpr double kL  = 0.0065;
+    static constexpr double kG  = 9.80665;
+    static constexpr double kM  = 0.0289644;
+    static constexpr double kR  = 8.31446;
+    static constexpr double kExp = (kG * kM) / (kR * kL);
+
+    sensors::BaroParams p;
+    p.alt_ref_m   = 0.0;
+    p.noise_std_m = 0.0;
+    sensors::Barometer baro(p);
+
+    physics::State s = makeHoverState();
+    s.position.z() = -2000.0; // 2000 m altitude (NED z negative = up)
+    const auto sample = baro.sample(s);
+
+    // Invert ISA pressure formula: h = (T0/L) * (1 - (P/P0)^(1/exponent))
+    const double ratio = static_cast<double>(sample.pressure_pa) / kP0;
+    const double alt_back = (kT0 / kL) * (1.0 - std::pow(ratio, 1.0 / kExp));
+    EXPECT_NEAR(alt_back, static_cast<double>(sample.altitude_m), 1.0)
+        << "back-calculated altitude must match reported altitude_m within 1 m";
 }
 
 // ── Magnetometer ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- `Barometer::sample` was returning a fixed 20°C regardless of altitude, while computing pressure from the ISA lapse rate — a mismatch growing to 37°C at 5 km
- PX4/ArduPilot uses the temperature field for EKF air-data calculations; the inconsistency corrupts that fusion path
- Temperature is now: `T_c = (kT0 − kL × altitude_msl) − 273.15 + ground_temp_offset_c`
- `BaroParams::temperature_c` renamed to `ground_temp_offset_c` (default 0.0) for non-standard-day simulation

## Test plan

- [ ] `Barometer.TemperatureDecreasesWithAltitude`: asserts temperature at 5000 m is below sea-level, within 0.1°C of ISA value (−17.5°C)
- [ ] `Barometer.TemperatureConsistentWithPressure`: back-calculates altitude from pressure via ISA, asserts within 1 m of `altitude_m`
- [ ] All existing barometer tests pass
- [ ] Full suite: 49/49

Closes #48