### PR TITLE
fix(sensors): derive GPS eph/epv from noise params and expose num_sats/fix_type in GPSParams

### DIFF
--- a/config/ardupilot_sitl.json
+++ b/config/ardupilot_sitl.json
@@ -54,7 +54,9 @@
     "pos_noise_std_m": 1.5,
     "alt_noise_std_m": 2.5,
     "vel_noise_std": 0.1,
-    "update_rate_hz": 5.0
+    "update_rate_hz": 5.0,
+    "num_sats": 12,
+    "fix_type": 3
   },
 
   "baro_params": {

--- a/config/default.json
+++ b/config/default.json
@@ -54,7 +54,9 @@
     "pos_noise_std_m": 1.5,
     "alt_noise_std_m": 2.5,
     "vel_noise_std": 0.1,
-    "update_rate_hz": 5.0
+    "update_rate_hz": 5.0,
+    "num_sats": 12,
+    "fix_type": 3
   },
 
   "baro_params": {

--- a/include/simuav/ConfigLoader.inl
+++ b/include/simuav/ConfigLoader.inl
@@ -90,6 +90,8 @@ inline SimConfig loadConfig(const std::string& path) {
         p.alt_noise_std_m  = g.value("alt_noise_std_m",  p.alt_noise_std_m);
         p.vel_noise_std    = g.value("vel_noise_std",    p.vel_noise_std);
         p.update_rate_hz   = g.value("update_rate_hz",   p.update_rate_hz);
+        p.num_sats         = g.value("num_sats",         p.num_sats);
+        p.fix_type         = g.value("fix_type",         p.fix_type);
     }
 
     if (j.contains("baro_params")) {

--- a/include/simuav/sensors/GPS.h
+++ b/include/simuav/sensors/GPS.h
@@ -5,13 +5,15 @@
 namespace simuav::sensors {
 
 struct GPSParams {
-    double lat_ref_deg{47.397742};    // Reference origin latitude
-    double lon_ref_deg{8.545594};     // Reference origin longitude
-    double alt_ref_m{488.0};         // Reference origin altitude MSL
-    double pos_noise_std_m{1.5};     // m, horizontal position noise (1-sigma)
-    double alt_noise_std_m{2.5};     // m, vertical position noise
-    double vel_noise_std{0.1};       // m/s, velocity noise per axis
-    double update_rate_hz{5.0};      // Hz, GPS update rate
+    double  lat_ref_deg{47.397742};   // Reference origin latitude
+    double  lon_ref_deg{8.545594};    // Reference origin longitude
+    double  alt_ref_m{488.0};        // Reference origin altitude MSL
+    double  pos_noise_std_m{1.5};    // m, horizontal position noise (1-sigma) — also sets eph
+    double  alt_noise_std_m{2.5};    // m, vertical position noise — also sets epv
+    double  vel_noise_std{0.1};      // m/s, velocity noise per axis
+    double  update_rate_hz{5.0};     // Hz, GPS update rate
+    uint8_t num_sats{12};            // reported satellite count
+    uint8_t fix_type{3};             // 3 = 3D fix
 };
 
 struct GPSSample {

--- a/src/sensors/GPS.cpp
+++ b/src/sensors/GPS.cpp
@@ -33,6 +33,11 @@ bool GPS::sample(const physics::State& state, GPSSample& out) {
     last_sample_.velocity_e = static_cast<float>(state.velocity.y() + white(params_.vel_noise_std));
     last_sample_.velocity_d = static_cast<float>(state.velocity.z() + white(params_.vel_noise_std));
 
+    last_sample_.eph      = static_cast<float>(params_.pos_noise_std_m);
+    last_sample_.epv      = static_cast<float>(params_.alt_noise_std_m);
+    last_sample_.num_sats = params_.num_sats;
+    last_sample_.fix_type = params_.fix_type;
+
     out = last_sample_;
     return true;
 }

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -96,6 +96,19 @@ TEST(ConfigLoader, LoadsDefaultJsonFile) {
     EXPECT_GT(cfg.mag_params.noise_std, 0.0);
 }
 
+TEST(ConfigLoader, LoadsGpsNumSatsAndFixType) {
+    const std::string path = writeTempJson(R"({
+        "gps_params": {
+            "num_sats": 8,
+            "fix_type": 2
+        }
+    })");
+
+    const SimConfig cfg = loadConfig(path);
+    EXPECT_EQ(cfg.gps_params.num_sats, 8u);
+    EXPECT_EQ(cfg.gps_params.fix_type, 2u);
+}
+
 TEST(ConfigLoader, LoadsArduPilotSitlJsonFile) {
     const SimConfig cfg = loadConfig(
         std::string(SIMUAV_SOURCE_DIR) + "/config/ardupilot_sitl.json");

--- a/tests/test_sensors.cpp
+++ b/tests/test_sensors.cpp
@@ -80,6 +80,24 @@ TEST(GPS, ThrottlesAtUpdateRate) {
     EXPECT_TRUE(gps.sample(s, out));
 }
 
+TEST(GPS, EphMatchesNoiseSigma) {
+    sensors::GPSParams p;
+    p.pos_noise_std_m = 3.0;
+    p.alt_noise_std_m = 5.0;
+    p.num_sats        = 8;
+    p.fix_type        = 3;
+    sensors::GPS gps(p);
+
+    physics::State s = makeHoverState();
+    sensors::GPSSample out;
+    ASSERT_TRUE(gps.sample(s, out));
+
+    EXPECT_FLOAT_EQ(out.eph, 3.0f);
+    EXPECT_FLOAT_EQ(out.epv, 5.0f);
+    EXPECT_EQ(out.num_sats, 8u);
+    EXPECT_EQ(out.fix_type, 3u);
+}
+
 // ── Barometer ────────────────────────────────────────────────────────────────
 
 TEST(Barometer, SeaLevelPressureNearP0) {


### PR DESCRIPTION
## Summary

- `GPSSample.eph` and `.epv` were struct-level defaults (1.5 m, 2.5 m) that were never written by `GPS::sample()`, even when the user changed `pos_noise_std_m` in config — causing the firmware EKF to weight measurements with incorrect confidence
- `GPS::sample()` now sets `eph = params_.pos_noise_std_m` and `epv = params_.alt_noise_std_m` on every new fix
- `num_sats` and `fix_type` added to `GPSParams` (defaulting to 12 and 3) so scenario scripts can configure them; `GPS::sample()` copies them into each sample
- `ConfigLoader.inl`, `config/default.json`, `config/ardupilot_sitl.json` updated

## Test plan

- [ ] `GPS.EphMatchesNoiseSigma`: constructs GPS with `pos_noise_std_m=3.0`, asserts `out.eph == 3.0f`, `out.epv == alt_noise_std_m`, `num_sats == 8`, `fix_type == 3`
- [ ] `ConfigLoader.LoadsGpsNumSatsAndFixType`: round-trip test for both new config fields
- [ ] Full suite: 49/49

Closes #50