### PR TITLE
fix(ci): permanently fix nightly e2e pipeline failures

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,11 +89,18 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: pip-venv-${{ hashFiles('px4-autopilot/Tools/setup/requirements.txt') }}
+          # v2: cache key bumped to force rebuild now that kconfiglib is required
+          key: pip-venv-${{ hashFiles('px4-autopilot/Tools/setup/requirements.txt') }}-v2
           restore-keys: pip-venv-
 
       - name: Install PX4 Python requirements
-        run: .venv/bin/pip install --upgrade pip -r px4-autopilot/Tools/setup/requirements.txt
+        run: |
+          .venv/bin/pip install --upgrade pip
+          .venv/bin/pip install -r px4-autopilot/Tools/setup/requirements.txt
+          # kconfiglib provides the 'menuconfig' module required by PX4's
+          # cmake/kconfig.cmake at SITL startup. It is not in requirements.txt
+          # for v1.14.0 but is checked at cmake configure time.
+          .venv/bin/pip install kconfiglib
 
       - name: Install pymavlink
         run: .venv/bin/pip install pymavlink

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -108,8 +108,12 @@ jobs:
       # ── Run end-to-end test ───────────────────────────────────────────────
 
       - name: Run E2E test
+        # Activate the venv so that cmake's find_package(Python3) resolves to
+        # the venv interpreter (which has kconfiglib) instead of /usr/bin/python3
+        # when PX4's kconfig.cmake runs on a fresh (cache-miss) build.
         run: |
-          .venv/bin/python3 scripts/e2e_px4_sitl.py \
+          source .venv/bin/activate
+          python3 scripts/e2e_px4_sitl.py \
             --px4-src px4-autopilot \
             --simuav ./build/simuav \
             --gps-timeout 30 \

--- a/.github/workflows/e2e_ardupilot.yml
+++ b/.github/workflows/e2e_ardupilot.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ardupilot
-          key: ardupilot-copter-4.5.7-${{ runner.os }}
+          key: ardupilot-copter-4.5.7-v2-${{ runner.os }}
 
       - name: Clone ArduPilot
         if: steps.cache-ardupilot.outputs.cache-hit != 'true'

--- a/.github/workflows/e2e_ardupilot.yml
+++ b/.github/workflows/e2e_ardupilot.yml
@@ -78,14 +78,31 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          key: pip-venv-ap-${{ hashFiles('ardupilot/requirements.txt') }}
+          # ArduCopter-4.5 has no requirements.txt at the repo root.
+          # Only pymavlink is needed for our e2e script; pin the key to a
+          # static version so the cache rebuilds only when explicitly bumped.
+          key: pip-venv-ap-v2-${{ runner.os }}
           restore-keys: pip-venv-ap-
 
-      - name: Install ArduPilot Python requirements
-        run: .venv/bin/pip install --upgrade pip -r ardupilot/requirements.txt
+      - name: Install Python packages
+        # sim_vehicle.py and our e2e script only need pymavlink and future.
+        # ArduCopter-4.5 has no root-level requirements.txt.
+        run: .venv/bin/pip install --upgrade pip pymavlink future
 
-      - name: Install pymavlink
-        run: .venv/bin/pip install pymavlink
+      - name: Build ArduCopter SITL binary
+        # Build once; the result is included in the cached ardupilot/ directory.
+        # Skipped automatically when the cache hits (binary already present).
+        id: build-ardupilot
+        run: |
+          if [ ! -f ardupilot/build/sitl/bin/arducopter ]; then
+            cd ardupilot
+            python3 -m venv /tmp/waf-venv
+            /tmp/waf-venv/bin/pip install -q future
+            ./waf configure --board sitl
+            ./waf copter -j4
+          else
+            echo "ArduCopter SITL binary already present — skipping build"
+          fi
 
       # ── Run end-to-end test ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Root causes

### PX4 SITL (`e2e.yml`)
PX4 v1.14.0's `cmake/kconfig.cmake` imports Python's `menuconfig` module at SITL startup. `menuconfig` is provided by `kconfiglib`, which is **not** listed in `px4-autopilot/Tools/setup/requirements.txt` for this version. The job was failing with `No module named 'menuconfig'` every night.

### ArduPilot SITL (`e2e_ardupilot.yml`)
ArduCopter-4.5.7 ships **no root-level `requirements.txt`**. The old step `pip install -r ardupilot/requirements.txt` always exited with `No such file or directory`. Additionally, the previous approach assumed the SITL binary was pre-cached, making it fragile on any cache miss.

## Fixes

**`e2e.yml`**
- Install `kconfiglib` explicitly after the main requirements file.
- Bump pip cache key to `-v2` to force a clean rebuild and avoid stale caches that pre-date this fix.

**`e2e_ardupilot.yml`**
- Remove the nonexistent `requirements.txt` install step.
- Replace with `pip install pymavlink future` (the only two packages needed).
- Use a static cache key `pip-venv-ap-v2-${{ runner.os }}` (no file hash to invalidate against a missing file).
- Add an explicit `waf` SITL binary build step guarded by a file-existence check, so the job builds the binary on cache miss instead of crashing.

## Test plan
- [ ] Trigger both workflows manually via `workflow_dispatch` and confirm green
- [ ] Verify nightly run passes on next scheduled execution