### PR TITLE
fix(logging): add uint64_t timestamp to every uLog DATA message

### DIFF
--- a/src/logging/ULogLogger.cpp
+++ b/src/logging/ULogLogger.cpp
@@ -21,20 +21,24 @@ static constexpr uint16_t kMsgIdAirData    = 3;
 
 // vehicle_local_position fields logged (subset)
 static constexpr char kFormatLocalPos[] =
-    "vehicle_local_position:float x;float y;float z;"
+    "vehicle_local_position:uint64_t timestamp;"
+    "float x;float y;float z;"
     "float vx;float vy;float vz;"
     "float ax;float ay;float az;"
     "float baro_alt;";
 
 static constexpr char kFormatImu[] =
-    "vehicle_imu:float ax;float ay;float az;float gx;float gy;float gz;";
+    "vehicle_imu:uint64_t timestamp;"
+    "float ax;float ay;float az;float gx;float gy;float gz;";
 
 static constexpr char kFormatGps[] =
-    "vehicle_gps_position:double lat;double lon;float alt;"
+    "vehicle_gps_position:uint64_t timestamp;"
+    "double lat;double lon;float alt;"
     "float vn;float ve;float vd;float eph;float epv;";
 
 static constexpr char kFormatAirData[] =
-    "vehicle_air_data:float pressure_pa;float altitude_m;float temperature_c;";
+    "vehicle_air_data:uint64_t timestamp;"
+    "float pressure_pa;float altitude_m;float temperature_c;";
 
 ULogLogger::ULogLogger(const std::string& path)
     : file_(path, std::ios::out | std::ios::binary | std::ios::trunc) {}
@@ -123,9 +127,12 @@ void ULogLogger::log(const physics::State&      state,
     // Each call writes one DATA record per subscribed topic.
     // msg_size = sizeof(payload) + 1 (for the msg_type byte).
 
+    const uint64_t timestamp_us = static_cast<uint64_t>(state.time * 1.0e6);
+
     {
         struct __attribute__((packed)) LocalPosPayload {
             uint16_t msg_id;
+            uint64_t timestamp;
             float x, y, z;
             float vx, vy, vz;
             float ax, ay, az;
@@ -133,6 +140,7 @@ void ULogLogger::log(const physics::State&      state,
         };
         LocalPosPayload pl{};
         pl.msg_id   = kMsgIdLocalPos;
+        pl.timestamp = timestamp_us;
         pl.x        = static_cast<float>(state.position.x());
         pl.y        = static_cast<float>(state.position.y());
         pl.z        = static_cast<float>(state.position.z());
@@ -151,11 +159,13 @@ void ULogLogger::log(const physics::State&      state,
     {
         struct __attribute__((packed)) ImuPayload {
             uint16_t msg_id;
+            uint64_t timestamp;
             float ax, ay, az;
             float gx, gy, gz;
         };
         ImuPayload pl{};
-        pl.msg_id = kMsgIdImu;
+        pl.msg_id    = kMsgIdImu;
+        pl.timestamp = timestamp_us;
         pl.ax     = static_cast<float>(imu.accel_body.x());
         pl.ay     = static_cast<float>(imu.accel_body.y());
         pl.az     = static_cast<float>(imu.accel_body.z());
@@ -170,13 +180,15 @@ void ULogLogger::log(const physics::State&      state,
     {
         struct __attribute__((packed)) GpsPayload {
             uint16_t msg_id;
+            uint64_t timestamp;
             double   lat, lon;
             float    alt;
             float    vn, ve, vd;
             float    eph, epv;
         };
         GpsPayload pl{};
-        pl.msg_id = kMsgIdGps;
+        pl.msg_id    = kMsgIdGps;
+        pl.timestamp = timestamp_us;
         pl.lat    = gps.latitude_deg;
         pl.lon    = gps.longitude_deg;
         pl.alt    = gps.altitude_m;
@@ -193,12 +205,14 @@ void ULogLogger::log(const physics::State&      state,
     {
         struct __attribute__((packed)) AirDataPayload {
             uint16_t msg_id;
+            uint64_t timestamp;
             float    pressure_pa;
             float    altitude_m;
             float    temperature_c;
         };
         AirDataPayload pl{};
-        pl.msg_id      = kMsgIdAirData;
+        pl.msg_id    = kMsgIdAirData;
+        pl.timestamp = timestamp_us;
         pl.pressure_pa = baro.pressure_pa;
         pl.altitude_m  = baro.altitude_m;
         pl.temperature_c = baro.temperature_c;

--- a/tests/test_ulog.cpp
+++ b/tests/test_ulog.cpp
@@ -180,3 +180,83 @@ TEST(ULogLogger, AllFourTopicsHaveDataMessages) {
     EXPECT_TRUE(seen[2]) << "DATA msg_id 2 (vehicle_gps_position) missing";
     EXPECT_TRUE(seen[3]) << "DATA msg_id 3 (vehicle_air_data) missing";
 }
+
+TEST(ULogLogger, FormatStringsContainTimestampFirstField) {
+    // Each FORMAT body is a raw string; verify "uint64_t timestamp" appears
+    // before any other field separator for all four topics.
+    const std::string path = "/tmp/simuav_test_fmt_ts.ulg";
+    {
+        simuav::logging::ULogLogger logger(path);
+        simuav::physics::State      state;
+        simuav::sensors::IMUSample  imu;
+        simuav::sensors::BaroSample baro{};
+        simuav::sensors::GPSSample  gps{};
+        logger.log(state, imu, baro, gps);
+    }
+
+    std::ifstream f(path, std::ios::binary);
+    ASSERT_TRUE(f.is_open());
+    skipBytes(f, 16);  // file header
+
+    // Skip FLAG_BITS
+    { uint16_t sz = readU16(f); skipBytes(f, sz); }
+
+    int fmt_with_timestamp = 0;
+    for (int i = 0; i < 4; ++i) {
+        uint16_t msg_size = readU16(f);
+        uint8_t  msg_type = readU8(f);
+        ASSERT_EQ(0x46, msg_type);
+        std::string body(static_cast<std::size_t>(msg_size) - 1, '\0');
+        ASSERT_TRUE(readExact(f, body.data(), body.size()));
+
+        // FORMAT body: "topic_name:field1;field2;..."
+        // The first field after ':' must be "uint64_t timestamp"
+        auto colon = body.find(':');
+        ASSERT_NE(std::string::npos, colon) << "FORMAT " << i << " has no ':'";
+        const std::string fields = body.substr(colon + 1);
+        EXPECT_EQ(0u, fields.find("uint64_t timestamp;"))
+            << "FORMAT " << i << " first field is not 'uint64_t timestamp': " << body;
+        ++fmt_with_timestamp;
+    }
+    EXPECT_EQ(4, fmt_with_timestamp);
+}
+
+TEST(ULogLogger, DataTimestampMatchesStateTime) {
+    // Write two log entries at known simulation times and verify that the
+    // timestamp field in each DATA message encodes state.time in microseconds.
+    const std::string path = "/tmp/simuav_test_ts.ulg";
+    constexpr double kTime1 = 1.5;   // seconds
+    constexpr double kTime2 = 3.25;
+    {
+        simuav::logging::ULogLogger logger(path);
+        simuav::physics::State      state;
+        simuav::sensors::IMUSample  imu;
+        simuav::sensors::BaroSample baro{};
+        simuav::sensors::GPSSample  gps{};
+        state.time = kTime1;
+        logger.log(state, imu, baro, gps);
+        state.time = kTime2;
+        logger.log(state, imu, baro, gps);
+    }
+
+    std::ifstream f(path, std::ios::binary);
+    ASSERT_TRUE(f.is_open());
+    skipBytes(f, 16);
+    { uint16_t sz = readU16(f); skipBytes(f, sz); }       // FLAG_BITS
+    for (int i = 0; i < 4; ++i) { uint16_t sz = readU16(f); skipBytes(f, sz); } // FORMATs
+    for (int i = 0; i < 4; ++i) { uint16_t sz = readU16(f); skipBytes(f, sz); } // SUBs
+
+    // First DATA message (local_position, msg_id 0) written for kTime1.
+    {
+        uint16_t msg_size = readU16(f);
+        uint8_t  msg_type = readU8(f);
+        ASSERT_EQ(0x44, msg_type);
+        uint16_t msg_id = readU16(f);
+        EXPECT_EQ(0u, msg_id);
+        uint64_t ts = 0;
+        ASSERT_TRUE(readExact(f, &ts, 8));
+        EXPECT_EQ(static_cast<uint64_t>(kTime1 * 1.0e6), ts);
+        // Skip rest of payload
+        skipBytes(f, static_cast<std::size_t>(msg_size) - 1 - 2 - 8);
+    }
+}


### PR DESCRIPTION
## Problem
The ULog spec requires every FORMAT definition to start with `uint64_t timestamp` (microseconds). All four topics (`vehicle_local_position`, `vehicle_imu`, `vehicle_gps_position`, `vehicle_air_data`) were missing this field, causing `pyulog` / Flight Review to reject or misparse the generated `.ulg` files.

## Fix
- Added `uint64_t timestamp;` as the first field in all four FORMAT strings.
- Added `uint64_t timestamp` to all four DATA payload structs.
- Populated from `state.time * 1e6` so the simulation clock is encoded in microseconds per spec.

## Tests
- `ULogLogger.FormatStringsContainTimestampFirstField` — parses the raw FORMAT bytes and asserts the first field is `uint64_t timestamp` for all four topics.
- `ULogLogger.DataTimestampMatchesStateTime` — writes entries at known `state.time` values and verifies the encoded timestamp in the first DATA message equals `state.time * 1e6`.

Closes #38