### PR TITLE
fix(ci): upload telemetry artifacts on PX4 e2e failure

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -118,3 +118,13 @@ jobs:
             --simuav ./build/simuav \
             --gps-timeout 30 \
             --arm-timeout 15
+
+      - name: Upload telemetry on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: telemetry-px4-e2e
+          path: |
+            telemetry.ulg
+            telemetry.json
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- Adds an `Upload telemetry on failure` step to `.github/workflows/e2e.yml`, mirroring the identical step already present in the ArduPilot nightly workflow.
- On failure, uploads `telemetry.ulg` and `telemetry.json` as artifact `telemetry-px4-e2e` for post-mortem analysis.

## Test plan
- [ ] Trigger a manual `workflow_dispatch` run; confirm the artifact step is skipped on success.
- [ ] On a known-failing run the artifact should appear in the GitHub Actions summary.

Closes #53