### PR TITLE
docs(claude): update CLAUDE.md for RK4, motor lag, Gauss-Markov IMU, StatusServer, uLog fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,19 +58,24 @@ Starts PX4 SITL + SimUAV, asserts GPS lock within 30 s and successful arm. Runs 
 src/main.cpp
     └── Simulator           orchestrates all subsystems, owns the 250 Hz loop
           ├── physics/
-          │   ├── QuadrotorModel   rigid-body dynamics (Euler integration, NED/FRD frames)
-          │   └── WindModel        mean wind + turbulence + discrete gusts
+          │   ├── QuadrotorModel   rigid-body dynamics (RK4 integration, NED/FRD frames,
+          │   │                    first-order motor lag via motor_time_constant_s)
+          │   └── WindModel        mean wind + Dryden turbulence + discrete gusts
           ├── sensors/
-          │   ├── IMU              specific force + angular rate, bias random walk
-          │   ├── GPS              geodetic position, throttled to update_rate_hz
-          │   ├── Barometer        ISA pressure → altitude
+          │   ├── IMU              specific force + angular rate; Gauss-Markov bias model
+          │   │                    + sinusoidal vibration injection on body-Z accel
+          │   ├── GPS              geodetic position, throttled to update_rate_hz;
+          │   │                    reports eph/epv/num_sats/fix_type
+          │   ├── Barometer        ISA lapse-rate temperature + pressure → altitude
           │   └── Magnetometer     Earth field rotated to body frame
           ├── comms/
           │   └── MAVLinkBridge    non-blocking UDP socket; sends HIL_SENSOR + HIL_GPS,
-          │                        receives HIL_ACTUATOR_CONTROLS
+          │                        receives HIL_ACTUATOR_CONTROLS / RC_CHANNELS_OVERRIDE
+          ├── observability/
+          │   └── StatusServer     UDP broadcast of JSON status snapshots at status_port
           └── logging/
               ├── JSONLogger       NDJSON, one line per step
-              └── ULogLogger       PX4 uLog binary format
+              └── ULogLogger       PX4 uLog binary format (with uint64_t timestamp per message)
 ```
 
 ### Frame conventions
@@ -104,20 +109,21 @@ Thrust in body: `[0, 0, −F_total]` (upward = negative body-Z).
 - **Outbound**: `HIL_SENSOR` every physics step (250 Hz); `HIL_GPS` at `gps_params.update_rate_hz` (default 5 Hz).
 - **Inbound**: `HIL_ACTUATOR_CONTROLS` (normalized [0,1], PX4 and ArduPilot) or `RC_CHANNELS_OVERRIDE` (PWM [1000–2000 µs], ArduPilot SITL only). Motor channels 1–4 map to motor indices 0–3.
 - Socket is **non-blocking** (`O_NONBLOCK`). If no packet arrives in a step, the previous motor command is reused.
-- Default ports: simulator binds `14561`, sends to firmware at `14560` (PX4 SITL default).
+- Default ports: simulator binds `mavlink_local_port` (default `14561`), sends to firmware at `mavlink_port` (default `14560`, PX4 SITL default). Both are configurable in the JSON config.
 - Firmware target is selected via `"firmware_target": "px4"` or `"firmware_target": "ardupilot"` in the config file (default: `"px4"`). The `ardupilotmega` MAVLink dialect header (a strict superset of `common`) is always included.
 
 ### Sensor noise model
 
 Each sensor class inherits `SensorBase` (a seeded `std::mt19937_64`). Sensors use:
 - **White noise**: `std_dev × N(0,1)` added to each output per sample.
-- **Bias random walk** (IMU only): bias vector incremented each step by `N(0, bias_std)`.
+- **Gauss-Markov bias** (IMU only): each bias axis follows `b[k] = exp(-dt/τ)·b[k-1] + N(0, σ_b)` so the bias is bounded at steady state (stationary std ≈ σ_b/√(1−exp(−2dt/τ))). Configurable via `accel_bias_instability`, `accel_bias_instability_tc_s`, `gyro_bias_instability`, `gyro_bias_instability_tc_s`.
+- **Vibration injection** (IMU only): sinusoidal signal added to body-Z accelerometer at `vibration_frequency_hz` with amplitude `vibration_amplitude_mps2`. Set to 0 to disable.
 - Seeds are fixed constants (1–4) so simulation runs are **deterministic by default**. Pass a different seed to the constructor to vary.
 
 ### Logging
 
 - **JSON** (`telemetry.json`): NDJSON, one JSON object per physics step. Fields: `t`, `pos[3]`, `vel[3]`, `att[4]` (w,x,y,z), `omega[3]`, `accel[3]`, `gyro[3]`, `baro_alt`, `gps_lat`, `gps_lon`.
-- **uLog** (`telemetry.ulg`): PX4 binary format. Writes file header + `FLAG_BITS` + four `FORMAT` messages (`vehicle_local_position`, `vehicle_imu`, `vehicle_gps_position`, `vehicle_air_data`) + four `SUBSCRIPTION` messages (msg_id 0–3) + one `DATA` message per step (msg_id 0 = `vehicle_local_position`). Open with `pyulog` or Flight Review.
+- **uLog** (`telemetry.ulg`): PX4 binary format. Writes file header + `FLAG_BITS` + four `FORMAT` messages (`vehicle_local_position`, `vehicle_imu`, `vehicle_gps_position`, `vehicle_air_data`) + four `SUBSCRIPTION` messages (msg_id 0–3) + four `DATA` messages per step (one per subscribed topic, each with a `uint64_t timestamp` field in microseconds). Open with `pyulog` or Flight Review.
 - **Replay** (`--replay <path>`): reads an NDJSON log, reconstructs `physics::State` from each entry, derives `accel_world` by finite-differencing consecutive velocity entries, and feeds the states through the sensor pipeline without connecting to firmware. See `include/simuav/LogReplayer.h`.
 
 ## Language rules
@@ -132,9 +138,10 @@ Each sensor class inherits `SensorBase` (a seeded `std::mt19937_64`). Sensors us
 | File | Why read it first |
 |------|------------------|
 | `include/simuav/Simulator.h` | Defines `SimConfig` and the loop order |
-| `include/simuav/physics/QuadrotorModel.h` | Motor layout, `State` struct, frame conventions |
-| `src/physics/QuadrotorModel.cpp` | Full force/torque derivation |
+| `include/simuav/physics/QuadrotorModel.h` | Motor layout, `State` struct, frame conventions, motor lag |
+| `src/physics/QuadrotorModel.cpp` | Full force/torque derivation and RK4 integrator |
 | `src/comms/MAVLinkBridge.cpp` | PWM→rad/s mapping; HIL message packing |
+| `include/simuav/StatusServer.h` | UDP status broadcast; `StatusSnapshot` struct |
 | `config/default.json` | All tuneable parameters with their default values |
 
 ++


### PR DESCRIPTION
## Summary
- Architecture tree updated: RK4 + motor lag in `QuadrotorModel`; Gauss-Markov + vibration in IMU; GPS fields; `StatusServer` added; uLog timestamp noted.
- Sensor noise model section: replaces stale "bias random walk" with accurate Gauss-Markov description.
- MAVLink bridge section: both local and remote ports are configurable via JSON config.
- uLog section: corrected "one DATA per step" → "four DATA per step".
- Key files table: adds `StatusServer.h`; updates physics entries to mention RK4 and motor lag.

Closes #44