### PR TITLE
feature(config): expose mavlink_local_port in SimConfig and config files

### DIFF
--- a/config/ardupilot_sitl.json
+++ b/config/ardupilot_sitl.json
@@ -2,6 +2,7 @@
   "dt": 0.004,
   "mavlink_host": "127.0.0.1",
   "mavlink_port": 9002,
+  "mavlink_local_port": 14561,
   "firmware_target": "ardupilot",
   "json_log_path": "telemetry.json",
   "ulog_path": "telemetry.ulg",

--- a/config/default.json
+++ b/config/default.json
@@ -2,6 +2,7 @@
   "dt": 0.004,
   "mavlink_host": "127.0.0.1",
   "mavlink_port": 14560,
+  "mavlink_local_port": 14561,
   "firmware_target": "px4",
   "json_log_path": "telemetry.json",
   "ulog_path": "telemetry.ulg",

--- a/include/simuav/ConfigLoader.inl
+++ b/include/simuav/ConfigLoader.inl
@@ -13,8 +13,9 @@ inline SimConfig loadConfig(const std::string& path) {
 
     cfg.dt             = j.value("dt",             cfg.dt);
     cfg.mavlink_host   = j.value("mavlink_host",   cfg.mavlink_host);
-    cfg.mavlink_port   = j.value("mavlink_port",   cfg.mavlink_port);
-    cfg.json_log_path  = j.value("json_log_path",  cfg.json_log_path);
+    cfg.mavlink_port        = j.value("mavlink_port",        cfg.mavlink_port);
+    cfg.mavlink_local_port  = j.value("mavlink_local_port",  cfg.mavlink_local_port);
+    cfg.json_log_path       = j.value("json_log_path",       cfg.json_log_path);
     cfg.ulog_path      = j.value("ulog_path",      cfg.ulog_path);
     cfg.status_port    = j.value("status_port",    cfg.status_port);
 

--- a/include/simuav/Simulator.h
+++ b/include/simuav/Simulator.h
@@ -27,6 +27,7 @@ struct SimConfig {
     double         dt{0.004};                  // s, physics timestep (250 Hz)
     std::string    mavlink_host{"127.0.0.1"};
     uint16_t       mavlink_port{14560};
+    uint16_t       mavlink_local_port{14561};    // UDP port the simulator binds to
     FirmwareTarget firmware_target{FirmwareTarget::PX4};
     std::string    json_log_path{"telemetry.json"};
     std::string    ulog_path{"telemetry.ulg"};

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -19,6 +19,7 @@ Simulator::Simulator(SimConfig config)
         comms::BridgeParams bp;
         bp.remote_host     = config_.mavlink_host;
         bp.remote_port     = config_.mavlink_port;
+        bp.local_port      = config_.mavlink_local_port;
         bp.max_motor_speed = config_.quad_params.max_motor_speed;
         bp.esc_exponent    = config_.quad_params.esc_exponent;
         bp.motor_spin_min  = config_.quad_params.motor_spin_min;

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -18,6 +18,7 @@ TEST(ConfigLoader, LoadsAllTopLevelFields) {
         "dt": 0.002,
         "mavlink_host": "192.168.1.1",
         "mavlink_port": 14550,
+        "mavlink_local_port": 15001,
         "json_log_path": "out.json",
         "ulog_path": "out.ulg"
     })");
@@ -27,6 +28,7 @@ TEST(ConfigLoader, LoadsAllTopLevelFields) {
     EXPECT_DOUBLE_EQ(cfg.dt, 0.002);
     EXPECT_EQ(cfg.mavlink_host, "192.168.1.1");
     EXPECT_EQ(cfg.mavlink_port, 14550);
+    EXPECT_EQ(15001u, cfg.mavlink_local_port);
     EXPECT_EQ(cfg.json_log_path, "out.json");
     EXPECT_EQ(cfg.ulog_path, "out.ulg");
 }
@@ -121,6 +123,19 @@ TEST(ConfigLoader, LoadsGpsNumSatsAndFixType) {
     const SimConfig cfg = loadConfig(path);
     EXPECT_EQ(cfg.gps_params.num_sats, 8u);
     EXPECT_EQ(cfg.gps_params.fix_type, 2u);
+}
+
+TEST(ConfigLoader, LoadsMavlinkLocalPort) {
+    const std::string path = writeTempJson(R"({ "mavlink_local_port": 15000 })");
+    const SimConfig cfg = loadConfig(path);
+    EXPECT_EQ(15000u, cfg.mavlink_local_port);
+}
+
+TEST(ConfigLoader, MavlinkLocalPortDefaultWhenAbsent) {
+    const std::string path = writeTempJson(R"({})");
+    const SimConfig cfg  = loadConfig(path);
+    const SimConfig dflt{};
+    EXPECT_EQ(dflt.mavlink_local_port, cfg.mavlink_local_port);
 }
 
 TEST(ConfigLoader, LoadsStatusPort) {


### PR DESCRIPTION
## Summary
- Adds `SimConfig::mavlink_local_port` (default `14561`) so the bridge's UDP bind port is configurable without source changes.
- Wires through `ConfigLoader.inl` → `Simulator.cpp` → `BridgeParams::local_port`.
- Documents the field in `config/default.json` and `config/ardupilot_sitl.json`.

## Use case
Running multiple simulator instances on the same machine (different firmware targets, parallel CI jobs) each needs a unique local port.

## Test plan
- [x] `LoadsMavlinkLocalPort` — explicit value loaded correctly
- [x] `MavlinkLocalPortDefaultWhenAbsent` — default 14561 preserved
- [x] `LoadsAllTopLevelFields` — extended to include the new field
- [x] Full suite: 66/66 pass

Closes #45