### PR TITLE
test(physics): add NED/FRD coordinate-frame regression test suite (closes #42)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,54 +144,64 @@ Each sensor class inherits `SensorBase` (a seeded `std::mt19937_64`). Sensors us
 | `include/simuav/StatusServer.h` | UDP status broadcast; `StatusSnapshot` struct |
 | `config/default.json` | All tuneable parameters with their default values |
 
-++
-++## Core Engineering Principles
-++
-++We build production-grade software.
-++
-++Priority order:
-++
-++1. Correctness
-++2. Maintainability
-++3. Simplicity
-++4. Security
-++5. Performance
-++6. Scalability
-++
-++Always avoid:
-++
-++- spaghetti code
-++- overengineering
-++- premature optimization
-++- hidden complexity
-++- fragile systems
-++- unclear ownership
-++
-++Prefer:
-++
-++- readable code
-++- modular design
-++- predictable behavior
-++- strong naming
-++- clean architecture
-++- testability
-++- small safe iterations
-++
-++Use principles pragmatically:
-++
-++- KISS
-++- SOLID
-++- DRY
-++- YAGNI
-++-
-++# Recommended Workflow
-++
-++Feature Work:
-++tech-lead → senior-dev → security-reviewer → qa-tester → documenter → devops-engineer
-++
-++Bug Fix:
-++debugger → tech-lead → senior-dev → qa-tester → documenter
-++
-++Technical Debt:
-++refactorer → qa-tester → documenter
-++
+
+## Core Engineering Principles
+
+We build production-grade software.
+
+**Priority order:**
+1. Correctness
+2. Maintainability
+3. Simplicity
+4. Security
+5. Performance
+6. Scalability
+
+**Always avoid:** spaghetti code, overengineering, premature optimization, hidden complexity, fragile systems, unclear ownership.
+
+**Prefer:** readable code, modular design, predictable behavior, strong naming, clean architecture, testability, small safe iterations.
+
+**Apply pragmatically:** KISS, SOLID, DRY, YAGNI.
+
+**Simulation-specific invariants:** determinism over raw speed, numerical stability over convenience, explicit behavior over implicit assumptions.
+
+## Multi-Agent Workflow
+
+Each agent has strictly isolated responsibilities. No agent performs another agent's role. Execution always follows the order below.
+
+### Agent order
+
+```
+Architect → Developer → Reviewer → Tester → Security → Performance → Integration → Refactorer → Documentation → DevOps
+```
+
+### Per-task shortcuts
+
+| Task type | Agents |
+|-----------|--------|
+| Feature | Architect → Developer → Reviewer → Tester → Security → Documentation → DevOps |
+| Bug fix | Developer → Reviewer → Tester → Documentation |
+| Technical debt | Reviewer → Refactorer → Tester → Documentation |
+| CI/infra | DevOps → Tester |
+
+### Agent responsibilities
+
+**Architect** — design before implementation. Outputs: class responsibilities, data flow, module boundaries, design rationale. Does NOT write full implementations.
+
+**Developer** — implement exactly what the Architect defined. C++17, RAII, `const`-correctness, `[[nodiscard]]` where applicable, clear ownership. No architectural decisions.
+
+**Reviewer** — critically evaluate the implementation. Detects bugs, edge cases, memory issues, design violations, unnecessary complexity. Does NOT rewrite — analyzes and points out.
+
+**Tester** — validate correctness via GoogleTest. Unit tests, edge cases, invalid inputs, regression tests. Simulation focus: numerical correctness, stability under extreme conditions, deterministic outputs.
+
+**Security** — identify undefined behavior, input validation gaps, memory safety issues, overflow/underflow. Outputs risk assessment and hardening recommendations.
+
+**Performance** — optimize real performance (not theoretical). Analyzes cache locality, data layout, hot paths, frame-time cost, hidden allocations. Simulation focus: deterministic timing, avoiding per-step heap allocation.
+
+**Integration** — verify modules work correctly together. Detects interface mismatches, incorrect coupling, broken cross-module assumptions.
+
+**Refactorer** — improve code quality without changing behavior: naming, structure, readability, duplication. No functional changes.
+
+**Documentation** — produce documentation that reflects actual code: headers, design rationale, config reference. Not theory.
+
+**DevOps** — CMake, CI/CD pipelines, reproducible builds, Linux parity. Ensures nightly e2e passes and caches are valid.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ add_executable(simuav_tests
     test_replay.cpp
     test_simulator.cpp
     test_status.cpp
+    test_frames.cpp
 )
 
 target_link_libraries(simuav_tests PRIVATE

--- a/tests/test_frames.cpp
+++ b/tests/test_frames.cpp
@@ -1,0 +1,114 @@
+#include <gtest/gtest.h>
+#include "simuav/physics/QuadrotorModel.h"
+#include "simuav/sensors/IMU.h"
+#include "simuav/sensors/Magnetometer.h"
+#include <Eigen/Geometry>
+#include <cmath>
+
+using namespace simuav::physics;
+using namespace simuav::sensors;
+
+static constexpr double kG = 9.80665;
+
+// Motor speed that produces hover thrust for the default quad params.
+static double hoverSpeed() {
+    QuadrotorParams p;
+    return std::sqrt((p.mass * kG) / (4.0 * p.k_thrust));
+}
+
+// At level attitude with all motors at hover speed, thrust is along body -Z.
+// Rotated to the NED world frame (identity rotation), thrust_world = (0, 0, -F).
+// Net z-accel from lastAccelWorld() = -F/m + g ≈ 0, with x=y=0. A sign error
+// in the thrust direction would give z > 0 at any motor speed above hover.
+TEST(FrameConventions, ThrustDirectionIsBodyNegativeZ) {
+    QuadrotorParams p;
+    p.motor_time_constant_s = 0.0;
+    p.aero_drag             = 0.0;
+    QuadrotorModel model(p);
+
+    // 10 % above hover so net z-accel is strictly negative if thrust is upward.
+    const double w = hoverSpeed() * 1.1;
+    model.integrate({w, w, w, w}, 1e-6);
+
+    EXPECT_NEAR(model.lastAccelWorld().x(), 0.0, 1e-6); // no lateral force
+    EXPECT_NEAR(model.lastAccelWorld().y(), 0.0, 1e-6);
+    EXPECT_LT(model.lastAccelWorld().z(), 0.0);          // thrust wins → upward = NED -z
+}
+
+// With zero thrust and zero drag, the only force is gravity: [0, 0, +g] NED.
+// Ground constraint is disabled so the clamp does not zero lastAccelWorld.
+TEST(FrameConventions, GravityIsNEDPositiveZ) {
+    QuadrotorParams p;
+    p.motor_time_constant_s    = 0.0;
+    p.aero_drag                = 0.0;
+    p.enable_ground_constraint = false;
+    QuadrotorModel model(p);
+
+    model.integrate({}, 1e-6);
+
+    EXPECT_NEAR(model.lastAccelWorld().z(), kG,  1e-9);
+    EXPECT_NEAR(model.lastAccelWorld().x(), 0.0, 1e-9);
+    EXPECT_NEAR(model.lastAccelWorld().y(), 0.0, 1e-9);
+}
+
+// Roll torque formula: L * k_thrust * (w0² + w2² − w1² − w3²).
+// Raising FL(0) and RL(2) (left motors) above FR(1)/RR(3) gives positive roll
+// torque → positive angular_velocity.x() (roll right in FRD).
+TEST(FrameConventions, RollTorqueIncreasesLeftMotors) {
+    QuadrotorParams p;
+    p.motor_time_constant_s = 0.0;
+    QuadrotorModel model(p);
+
+    const double w    = hoverSpeed();
+    const double w_hi = w * 1.2;
+    const double w_lo = w * 0.8;
+    model.integrate({w_hi, w_lo, w_hi, w_lo}, 0.001);
+
+    EXPECT_GT(model.state().angular_velocity.x(), 0.0);
+}
+
+// At hover equilibrium the net world acceleration is zero.
+// The accelerometer measures specific force = (world_accel − gravity) in body frame.
+// With level attitude: specific_force_body = [0, 0, -g].
+TEST(FrameConventions, IMUSpecificForceEqualsNegativeGravityAtHover) {
+    QuadrotorParams qp;
+    qp.motor_time_constant_s = 0.0;
+    QuadrotorModel model(qp);
+
+    const double w = hoverSpeed();
+    model.integrate({w, w, w, w}, 1e-6);
+
+    IMUParams ip;
+    ip.accel_arw_std          = 0.0;
+    ip.accel_bias_instability = 0.0;
+    ip.gyro_arw_std           = 0.0;
+    ip.gyro_bias_instability  = 0.0;
+    IMU imu(ip);
+
+    const IMUSample s = imu.sample(model.state(), model.lastAccelWorld());
+    EXPECT_NEAR(s.accel_body.x(),  0.0, 0.01);
+    EXPECT_NEAR(s.accel_body.y(),  0.0, 0.01);
+    EXPECT_NEAR(s.accel_body.z(), -kG,  0.01);
+}
+
+// With a 90° right-roll attitude the NED down component of Earth's field maps
+// to body Y, and the NED north component maps to body X.
+// Rotation matrix (body→NED) for Rx(90°): body_field = R^T * earth_ned gives
+//   body.x = north, body.y = down, body.z = -east.
+TEST(FrameConventions, MagnetometerBodyFrameRotatesWithAttitude) {
+    MagParams mp;
+    mp.noise_std = 0.0;
+    Magnetometer mag(mp);
+
+    State s;
+    s.attitude = Eigen::Quaterniond(
+        Eigen::AngleAxisd(M_PI / 2.0, Eigen::Vector3d::UnitX()));
+
+    const MagSample ms = mag.sample(s);
+
+    const float earth_x = static_cast<float>(mp.earth_field_ned.x()); // north
+    const float earth_z = static_cast<float>(mp.earth_field_ned.z()); // down
+
+    EXPECT_NEAR(ms.field_body.x(),  earth_x, 1e-4f); // body-X = NED-north
+    EXPECT_NEAR(ms.field_body.y(),  earth_z, 1e-4f); // body-Y = NED-down
+}


### PR DESCRIPTION
## Summary
- New file `tests/test_frames.cpp` with 5 `TEST` cases that pin the NED/FRD sign conventions across the physics and sensor pipeline.
- `tests/CMakeLists.txt` updated to include `test_frames.cpp`.
- CLAUDE.md updated with the multi-agent workflow (carried forward from the ground-constraint branch).

## Tests added

| Test | What it pins |
|------|-------------|
| `ThrustDirectionIsBodyNegativeZ` | Motors above hover → `lastAccelWorld().z() < 0` (upward in NED = thrust in body -Z) |
| `GravityIsNEDPositiveZ` | Zero thrust → `lastAccelWorld().z() ≈ +9.80665` |
| `RollTorqueIncreasesLeftMotors` | FL/RL > FR/RR → `angular_velocity.x() > 0` (right roll in FRD) |
| `IMUSpecificForceEqualsNegativeGravityAtHover` | At hover, IMU specific force ≈ `[0, 0, −g]` |
| `MagnetometerBodyFrameRotatesWithAttitude` | 90° right roll → body-Y field ≈ NED-down field component |

## Test plan
- [x] 76 unit tests pass (`./build/tests/simuav_tests`)
- [x] 5 new frame tests run in < 1 ms combined (acceptance criterion: < 100 ms)
- [x] No changes to production code