### PR TITLE
fix(ci): resolve nightly e2e failures for PX4 and ArduPilot SITL

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -108,6 +108,18 @@ jobs:
       - name: Install pymavlink
         run: .venv/bin/pip install pymavlink
 
+      # ── Build PX4 SITL binary (separate step so it is cached before the test) ──
+      # The px4-autopilot cache path includes build/ so the compiled binary
+      # persists across runs. Subsequent runs hit the cache and skip this step.
+      - name: Build PX4 SITL binary
+        run: |
+          if [ ! -f px4-autopilot/build/px4_sitl_default/bin/px4 ]; then
+            source .venv/bin/activate
+            make -C px4-autopilot px4_sitl_default -j4
+          else
+            echo "PX4 SITL binary already present — skipping build"
+          fi
+
       # ── Run end-to-end test ───────────────────────────────────────────────
 
       - name: Run E2E test
@@ -119,8 +131,8 @@ jobs:
           python3 scripts/e2e_px4_sitl.py \
             --px4-src px4-autopilot \
             --simuav ./build/simuav \
-            --gps-timeout 30 \
-            --arm-timeout 15
+            --gps-timeout 60 \
+            --arm-timeout 30
 
       - name: Upload telemetry on failure
         if: failure()

--- a/.github/workflows/e2e_ardupilot.yml
+++ b/.github/workflows/e2e_ardupilot.yml
@@ -97,7 +97,8 @@ jobs:
           if [ ! -f ardupilot/build/sitl/bin/arducopter ]; then
             cd ardupilot
             python3 -m venv /tmp/waf-venv
-            /tmp/waf-venv/bin/pip install -q future
+            # empy==3.3.4 is required by waf to process ArduPilot .h.in templates
+            /tmp/waf-venv/bin/pip install -q future 'empy==3.3.4'
             ./waf configure --board sitl
             ./waf copter -j4
           else

--- a/scripts/e2e_ardupilot_sitl.py
+++ b/scripts/e2e_ardupilot_sitl.py
@@ -201,7 +201,10 @@ def main() -> int:
         mav = mavutil.mavlink_connection(f"udpin:0.0.0.0:{GCS_PORT}")
 
         _info(f"Waiting for heartbeat (timeout {HEARTBEAT_TIMEOUT} s) ...")
-        mav.wait_heartbeat(timeout=HEARTBEAT_TIMEOUT)
+        hb = mav.wait_heartbeat(timeout=HEARTBEAT_TIMEOUT)
+        if hb is None:
+            _die(f"No MAVLink heartbeat from ArduPilot within {HEARTBEAT_TIMEOUT} s — "
+                 "SITL may not have started")
         _info(f"Heartbeat received (system {mav.target_system}, "
               f"component {mav.target_component})")
 

--- a/scripts/e2e_px4_sitl.py
+++ b/scripts/e2e_px4_sitl.py
@@ -170,7 +170,10 @@ def main() -> int:
         mav = mavutil.mavlink_connection(f"udpin:0.0.0.0:{GCS_PORT}")
 
         _info(f"Waiting for heartbeat (timeout {HEARTBEAT_TIMEOUT} s) ...")
-        mav.wait_heartbeat(timeout=HEARTBEAT_TIMEOUT)
+        hb = mav.wait_heartbeat(timeout=HEARTBEAT_TIMEOUT)
+        if hb is None:
+            _die(f"No MAVLink heartbeat from PX4 within {HEARTBEAT_TIMEOUT} s — "
+                 "SITL may not have started")
         _info(f"Heartbeat received (system {mav.target_system}, "
               f"component {mav.target_component})")
 


### PR DESCRIPTION
## Root causes

### ArduPilot (`empy` missing)
`waf copter` calls ArduPilot's `.h.in` template processor which requires `empy==3.3.4`. Only `future` was installed in the waf venv, so `waf configure` succeeded but `waf copter` exited immediately with:
> you need to install empy with 'python -m pip install empy==3.3.4'

### PX4 (binary not built before test)
`make px4_sitl_default none_iris` both **builds and runs** PX4 SITL. With a cold cache, the build takes 10–30 minutes. The e2e Python script only slept 3 s before polling for a heartbeat — PX4 was still compiling, so `wait_heartbeat()` timed out and returned `None`. The script silently continued with `target_system=0`, then waited 30 s for a GPS fix that never came.

## Fixes

| What | Fix |
|------|-----|
| ArduPilot waf venv | Add `empy==3.3.4` to `pip install -q future ...` |
| PX4 binary not ready | New "Build PX4 SITL binary" CI step pre-builds before the test; binary lives in `px4-autopilot/build/` which is already in the source cache |
| GPS / arm timeouts | 30 s → 60 s GPS, 15 s → 30 s arm (more headroom for EKF cold start) |
| Silent heartbeat miss | `wait_heartbeat()` return value checked in both scripts; `None` → hard failure with clear message |

## Why this is the last fix
- ArduPilot: one-line `empy` pin — deterministic.
- PX4: binary is now built in its own CI step and cached. Subsequent runs find the pre-built binary and skip the build entirely. First run is the only expensive one.

## Test plan
- [x] Unit tests unaffected (no production code changed)
- [ ] Nightly e2e runs after merge to validate