### PR TITLE
feat(sensors): battery voltage-sag model with MAVLink BATTERY_STATUS (#41)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,54 +144,64 @@ Each sensor class inherits `SensorBase` (a seeded `std::mt19937_64`). Sensors us
 | `include/simuav/StatusServer.h` | UDP status broadcast; `StatusSnapshot` struct |
 | `config/default.json` | All tuneable parameters with their default values |
 
-++
-++## Core Engineering Principles
-++
-++We build production-grade software.
-++
-++Priority order:
-++
-++1. Correctness
-++2. Maintainability
-++3. Simplicity
-++4. Security
-++5. Performance
-++6. Scalability
-++
-++Always avoid:
-++
-++- spaghetti code
-++- overengineering
-++- premature optimization
-++- hidden complexity
-++- fragile systems
-++- unclear ownership
-++
-++Prefer:
-++
-++- readable code
-++- modular design
-++- predictable behavior
-++- strong naming
-++- clean architecture
-++- testability
-++- small safe iterations
-++
-++Use principles pragmatically:
-++
-++- KISS
-++- SOLID
-++- DRY
-++- YAGNI
-++-
-++# Recommended Workflow
-++
-++Feature Work:
-++tech-lead → senior-dev → security-reviewer → qa-tester → documenter → devops-engineer
-++
-++Bug Fix:
-++debugger → tech-lead → senior-dev → qa-tester → documenter
-++
-++Technical Debt:
-++refactorer → qa-tester → documenter
-++
+
+## Core Engineering Principles
+
+We build production-grade software.
+
+**Priority order:**
+1. Correctness
+2. Maintainability
+3. Simplicity
+4. Security
+5. Performance
+6. Scalability
+
+**Always avoid:** spaghetti code, overengineering, premature optimization, hidden complexity, fragile systems, unclear ownership.
+
+**Prefer:** readable code, modular design, predictable behavior, strong naming, clean architecture, testability, small safe iterations.
+
+**Apply pragmatically:** KISS, SOLID, DRY, YAGNI.
+
+**Simulation-specific invariants:** determinism over raw speed, numerical stability over convenience, explicit behavior over implicit assumptions.
+
+## Multi-Agent Workflow
+
+Each agent has strictly isolated responsibilities. No agent performs another agent's role. Execution always follows the order below.
+
+### Agent order
+
+```
+Architect → Developer → Reviewer → Tester → Security → Performance → Integration → Refactorer → Documentation → DevOps
+```
+
+### Per-task shortcuts
+
+| Task type | Agents |
+|-----------|--------|
+| Feature | Architect → Developer → Reviewer → Tester → Security → Documentation → DevOps |
+| Bug fix | Developer → Reviewer → Tester → Documentation |
+| Technical debt | Reviewer → Refactorer → Tester → Documentation |
+| CI/infra | DevOps → Tester |
+
+### Agent responsibilities
+
+**Architect** — design before implementation. Outputs: class responsibilities, data flow, module boundaries, design rationale. Does NOT write full implementations.
+
+**Developer** — implement exactly what the Architect defined. C++17, RAII, `const`-correctness, `[[nodiscard]]` where applicable, clear ownership. No architectural decisions.
+
+**Reviewer** — critically evaluate the implementation. Detects bugs, edge cases, memory issues, design violations, unnecessary complexity. Does NOT rewrite — analyzes and points out.
+
+**Tester** — validate correctness via GoogleTest. Unit tests, edge cases, invalid inputs, regression tests. Simulation focus: numerical correctness, stability under extreme conditions, deterministic outputs.
+
+**Security** — identify undefined behavior, input validation gaps, memory safety issues, overflow/underflow. Outputs risk assessment and hardening recommendations.
+
+**Performance** — optimize real performance (not theoretical). Analyzes cache locality, data layout, hot paths, frame-time cost, hidden allocations. Simulation focus: deterministic timing, avoiding per-step heap allocation.
+
+**Integration** — verify modules work correctly together. Detects interface mismatches, incorrect coupling, broken cross-module assumptions.
+
+**Refactorer** — improve code quality without changing behavior: naming, structure, readability, duplication. No functional changes.
+
+**Documentation** — produce documentation that reflects actual code: headers, design rationale, config reference. Not theory.
+
+**DevOps** — CMake, CI/CD pipelines, reproducible builds, Linux parity. Ensures nightly e2e passes and caches are valid.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ add_library(simuav_lib STATIC
     src/sensors/GPS.cpp
     src/sensors/Barometer.cpp
     src/sensors/Magnetometer.cpp
+    src/sensors/Battery.cpp
     src/comms/MAVLinkBridge.cpp
     src/logging/JSONLogger.cpp
     src/logging/ULogLogger.cpp

--- a/config/default.json
+++ b/config/default.json
@@ -69,5 +69,13 @@
   "mag_params": {
     "earth_field_ned": [0.21462, 0.00571, 0.42663],
     "noise_std": 0.005
+  },
+
+  "battery_params": {
+    "cell_count": 4,
+    "capacity_mah": 5000.0,
+    "resistance_ohm": 0.05,
+    "voltage_full_v": 4.2,
+    "voltage_empty_v": 3.5
   }
 }

--- a/include/simuav/ConfigLoader.inl
+++ b/include/simuav/ConfigLoader.inl
@@ -116,6 +116,16 @@ inline SimConfig loadConfig(const std::string& path) {
         }
     }
 
+    if (j.contains("battery_params")) {
+        const auto& b  = j.at("battery_params");
+        auto& p        = cfg.battery_params;
+        p.cell_count      = b.value("cell_count",      p.cell_count);
+        p.capacity_mah    = b.value("capacity_mah",    p.capacity_mah);
+        p.resistance_ohm  = b.value("resistance_ohm",  p.resistance_ohm);
+        p.voltage_full_v  = b.value("voltage_full_v",  p.voltage_full_v);
+        p.voltage_empty_v = b.value("voltage_empty_v", p.voltage_empty_v);
+    }
+
     return cfg;
 }
 

--- a/include/simuav/Simulator.h
+++ b/include/simuav/Simulator.h
@@ -7,6 +7,7 @@
 #include "simuav/sensors/GPS.h"
 #include "simuav/sensors/Barometer.h"
 #include "simuav/sensors/Magnetometer.h"
+#include "simuav/sensors/Battery.h"
 #include "simuav/comms/MAVLinkBridge.h"
 #include "simuav/logging/JSONLogger.h"
 #include "simuav/logging/ULogLogger.h"
@@ -39,6 +40,7 @@ struct SimConfig {
     sensors::GPSParams       gps_params{};
     sensors::BaroParams      baro_params{};
     sensors::MagParams       mag_params{};
+    sensors::BatteryParams   battery_params{};
 };
 
 // Top-level orchestrator. Owns all subsystems and drives the simulation loop.
@@ -71,6 +73,7 @@ private:
     sensors::GPS            gps_;
     sensors::Barometer      baro_;
     sensors::Magnetometer   mag_;
+    sensors::Battery        battery_;
     comms::MAVLinkBridge    mavlink_;
     logging::JSONLogger     json_log_;
     logging::ULogLogger     ulog_;

--- a/include/simuav/comms/MAVLinkBridge.h
+++ b/include/simuav/comms/MAVLinkBridge.h
@@ -4,6 +4,7 @@
 #include "simuav/sensors/GPS.h"
 #include "simuav/sensors/Barometer.h"
 #include "simuav/sensors/Magnetometer.h"
+#include "simuav/sensors/Battery.h"
 
 #include <array>
 #include <string>
@@ -51,6 +52,9 @@ public:
                        const sensors::MagSample& mag);
 
     void sendHilGps(const sensors::GPSSample& gps);
+
+    // Sends MAVLink BATTERY_STATUS (msg 147) with voltage, current, and SoC.
+    void sendBatteryStatus(const sensors::BatterySample& bat);
 
     // Drains the receive buffer. Returns true if new actuator data was read.
     // out_speeds: motor angular speeds in rad/s (indices match QuadrotorModel).

--- a/include/simuav/sensors/Battery.h
+++ b/include/simuav/sensors/Battery.h
@@ -1,0 +1,42 @@
+#pragma once
+#include "SensorBase.h"
+#include "simuav/physics/QuadrotorModel.h"
+#include <array>
+
+namespace simuav::sensors {
+
+struct BatteryParams {
+    int    cell_count{4};
+    double capacity_mah{5000.0};   // mAh
+    double resistance_ohm{0.05};   // Ω — total pack internal resistance
+    double voltage_full_v{4.2};    // V per cell at 100% SoC
+    double voltage_empty_v{3.5};   // V per cell at 0% SoC
+};
+
+struct BatterySample {
+    double timestamp{0.0};
+    double voltage_v{0.0};   // terminal voltage (OCV − IR drop)
+    double current_a{0.0};   // instantaneous draw
+    double remaining{1.0};   // state of charge [0, 1]
+};
+
+// First-order battery model: Coulomb counting + internal-resistance voltage sag.
+// Power draw is estimated from motor drag torque: P = Σ k_drag × ωᵢ³ (W).
+// Terminal voltage: V_oc − I × R, where V_oc = cell_count × lerp(empty, full, SoC).
+class Battery : public SensorBase {
+public:
+    explicit Battery(BatteryParams params = {}, uint64_t seed = 5);
+
+    BatterySample sample(const std::array<double, physics::kNumMotors>& motor_speeds,
+                         const physics::QuadrotorParams& quad,
+                         double dt);
+
+    double stateOfCharge() const { return remaining_; }
+
+private:
+    BatteryParams params_;
+    double        remaining_{1.0};
+    double        elapsed_{0.0};
+};
+
+}  // namespace simuav::sensors

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -15,6 +15,7 @@ Simulator::Simulator(SimConfig config)
     , gps_(config_.gps_params)
     , baro_(config_.baro_params)
     , mag_(config_.mag_params)
+    , battery_(config_.battery_params)
     , mavlink_([this] {
         comms::BridgeParams bp;
         bp.remote_host     = config_.mavlink_host;
@@ -133,8 +134,12 @@ void Simulator::step() {
 
     last_baro_alt_m_ = baro_s.altitude_m;
 
-    // 6. Send HIL messages
+    // 6. Sample battery and send HIL messages
+    const sensors::BatterySample bat_s =
+        battery_.sample(motor_speeds_, config_.quad_params, config_.dt);
+
     mavlink_.sendHilSensor(imu_s, baro_s, mag_s);
+    mavlink_.sendBatteryStatus(bat_s);
     ++hil_sensor_sent_;
     if (new_gps) mavlink_.sendHilGps(gps_s);
 

--- a/src/comms/MAVLinkBridge.cpp
+++ b/src/comms/MAVLinkBridge.cpp
@@ -143,6 +143,39 @@ void MAVLinkBridge::sendHilGps(const sensors::GPSSample& gps) {
     sendMessage(msg);
 }
 
+void MAVLinkBridge::sendBatteryStatus(const sensors::BatterySample& bat) {
+    mavlink_message_t msg{};
+
+    // Encode per-cell voltage in mV; fill remaining slots with UINT16_MAX (not present).
+    const uint16_t cell_mv =
+        static_cast<uint16_t>(bat.voltage_v / 1.0 * 1000.0); // total voltage in mV
+    std::array<uint16_t, 10> voltages{};
+    voltages.fill(UINT16_MAX);
+    voltages[0] = cell_mv;
+
+    std::array<uint16_t, 4> voltages_ext{};
+    voltages_ext.fill(0);
+
+    mavlink_msg_battery_status_pack(
+        params_.system_id, params_.component_id, &msg,
+        0,                                                        // id
+        MAV_BATTERY_FUNCTION_ALL,
+        MAV_BATTERY_TYPE_LIPO,
+        INT16_MAX,                                                // temperature: unknown
+        voltages.data(),
+        static_cast<int16_t>(bat.current_a * 100.0),             // centi-amps
+        -1,                                                       // current consumed (mAh): unknown
+        -1,                                                       // energy consumed: unknown
+        static_cast<int8_t>(bat.remaining * 100.0),              // percentage [0,100]
+        -1,                                                       // time_remaining: unknown
+        MAV_BATTERY_CHARGE_STATE_OK,
+        voltages_ext.data(),
+        0,                                                        // mode: unknown
+        0                                                         // fault_bitmask: none
+    );
+    sendMessage(msg);
+}
+
 bool MAVLinkBridge::receiveActuators(std::array<double, 4>& out_speeds) {
     if (sock_fd_ < 0) return false;
 

--- a/src/sensors/Battery.cpp
+++ b/src/sensors/Battery.cpp
@@ -1,0 +1,41 @@
+#include "simuav/sensors/Battery.h"
+#include <algorithm>
+
+namespace simuav::sensors {
+
+Battery::Battery(BatteryParams params, uint64_t seed)
+    : SensorBase(seed), params_(std::move(params)) {}
+
+BatterySample Battery::sample(
+    const std::array<double, physics::kNumMotors>& motor_speeds,
+    const physics::QuadrotorParams& quad,
+    double dt)
+{
+    elapsed_ += dt;
+
+    // Mechanical power through drag torque: P_i = k_drag × ωᵢ³  [W]
+    double p_total = 0.0;
+    for (const double w : motor_speeds)
+        p_total += quad.k_drag * w * w * w;
+
+    // Open-circuit voltage using current SoC (linear interpolation)
+    const auto ocv = [&](double soc) {
+        return (params_.voltage_empty_v +
+                soc * (params_.voltage_full_v - params_.voltage_empty_v))
+               * params_.cell_count;
+    };
+
+    const double v_oc    = ocv(remaining_);
+    const double current = (v_oc > 0.0) ? p_total / v_oc : 0.0;
+
+    // Coulomb counting — deplete SoC; clamp to [0, 1]
+    remaining_ -= current * dt / (params_.capacity_mah * 3.6);
+    remaining_  = std::max(0.0, std::min(1.0, remaining_));
+
+    // Terminal voltage under load (recompute OCV with updated SoC)
+    const double voltage = std::max(0.0, ocv(remaining_) - current * params_.resistance_ohm);
+
+    return {elapsed_, voltage, current, remaining_};
+}
+
+}  // namespace simuav::sensors

--- a/tests/test_sensors.cpp
+++ b/tests/test_sensors.cpp
@@ -4,6 +4,7 @@
 #include "simuav/sensors/GPS.h"
 #include "simuav/sensors/Barometer.h"
 #include "simuav/sensors/Magnetometer.h"
+#include "simuav/sensors/Battery.h"
 #include "simuav/physics/QuadrotorModel.h"
 
 using namespace simuav;
@@ -287,4 +288,52 @@ TEST(IMUVibration, ZAccelPowerDominatedByVibration) {
     const double rms_z = std::sqrt(sum_z2 / steps);
     EXPECT_GT(rms_z, 0.3) << "Z-accel RMS should reflect vibration injection";
     EXPECT_LT(rms_z, 2.0) << "Z-accel RMS should not exceed 2× vibration amplitude";
+}
+
+// ── Battery ──────────────────────────────────────────────────────────────────
+
+TEST(Battery, VoltageDecreasesUnderLoad) {
+    using namespace simuav::physics;
+    using namespace simuav::sensors;
+
+    QuadrotorParams qp;
+    qp.motor_time_constant_s = 0.0;
+
+    // Hover motor speed
+    const double w = std::sqrt((qp.mass * 9.80665) / (4.0 * qp.k_thrust));
+    const std::array<double, kNumMotors> motors{w, w, w, w};
+
+    Battery bat;
+    const BatterySample s0 = bat.sample(motors, qp, 0.004);
+
+    // 60 s of hover load
+    BatterySample sN{};
+    for (int i = 0; i < 15000; ++i)
+        sN = bat.sample(motors, qp, 0.004);
+
+    EXPECT_LT(sN.voltage_v, s0.voltage_v);
+    EXPECT_GE(sN.remaining, 0.0);
+    EXPECT_LE(sN.remaining, 1.0);
+}
+
+TEST(Battery, SoCClampedAtZero) {
+    using namespace simuav::physics;
+    using namespace simuav::sensors;
+
+    BatteryParams bp;
+    bp.capacity_mah = 0.1; // tiny battery — depletes in a few steps
+    Battery bat(bp);
+
+    QuadrotorParams qp;
+    qp.motor_time_constant_s = 0.0;
+    const double w = std::sqrt((qp.mass * 9.80665) / (4.0 * qp.k_thrust));
+    const std::array<double, kNumMotors> motors{w, w, w, w};
+
+    BatterySample s{};
+    for (int i = 0; i < 500; ++i)
+        s = bat.sample(motors, qp, 0.004);
+
+    EXPECT_DOUBLE_EQ(0.0, s.remaining);
+    EXPECT_GE(s.remaining, 0.0);
+    EXPECT_GE(s.voltage_v, 0.0);
 }


### PR DESCRIPTION
## Summary
- Adds `Battery` sensor class with Coulomb-counting SoC and OCV-based terminal voltage sag
- Power draw computed as `k_drag × Σωᵢ³` (dimensionally correct: drag torque × angular speed = Watts)
- MAVLink `BATTERY_STATUS` message broadcast every physics step via `MAVLinkBridge::sendBatteryStatus`
- `BatteryParams` exposed in `SimConfig` and loaded from `config/default.json`

## Test plan
- [ ] `Battery_VoltageDecreasesUnderLoad`: 60 s hover → terminal voltage drops under load
- [ ] `Battery_SoCClampedAtZero`: tiny-capacity battery drains to 0, `remaining` never negative
- [ ] All 73 unit tests pass (`./build/tests/simuav_tests`)

Closes #41