### PR TITLE
feat(scenario): --scenario flag for time-triggered simulation events (#40)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(simuav_lib STATIC
     src/logging/JSONLogger.cpp
     src/logging/ULogLogger.cpp
     src/Simulator.cpp
+    src/ScenarioLoader.cpp
     src/LogReplayer.cpp
     src/StatusServer.cpp
 )

--- a/include/simuav/ScenarioLoader.h
+++ b/include/simuav/ScenarioLoader.h
@@ -1,0 +1,19 @@
+#pragma once
+#include <nlohmann/json.hpp>
+#include <string>
+#include <vector>
+
+namespace simuav {
+
+struct ScenarioEvent {
+    double          time_s{0.0};
+    std::string     type{};
+    nlohmann::json  params{};
+};
+
+// Parses a JSON array of scenario events from `path`.
+// Returns events sorted ascending by time_s.
+// Throws std::runtime_error if the file cannot be opened or is malformed.
+[[nodiscard]] std::vector<ScenarioEvent> loadScenario(const std::string& path);
+
+} // namespace simuav

--- a/include/simuav/Simulator.h
+++ b/include/simuav/Simulator.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "simuav/FirmwareTarget.h"
+#include "simuav/ScenarioLoader.h"
 #include "simuav/StatusServer.h"
 #include "simuav/physics/QuadrotorModel.h"
 #include "simuav/physics/WindModel.h"
@@ -13,8 +14,10 @@
 #include "simuav/logging/ULogLogger.h"
 
 #include <atomic>
+#include <cstddef>
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace simuav {
 
@@ -47,10 +50,11 @@ struct SimConfig {
 //
 // Loop order per step:
 //   1. receiveActuators()  – pull latest motor commands from firmware (non-blocking)
-//   2. integrate()         – advance physics by dt
-//   3. sampleSensors()     – apply noise models
-//   4. sendHilMessages()   – push sensor data to firmware
-//   5. log()               – write JSON + uLog records
+//   2. dispatchScenarioEvents() – fire any events whose time_s <= sim_time
+//   3. integrate()         – advance physics by dt
+//   4. sampleSensors()     – apply noise models
+//   5. sendHilMessages()   – push sensor data to firmware
+//   6. log()               – write JSON + uLog records
 class Simulator {
 public:
     explicit Simulator(SimConfig config);
@@ -59,11 +63,15 @@ public:
     void run();
     void stop();
 
+    // Load and arm a scenario file. Must be called before run().
+    void loadScenario(const std::string& path);
+
     const physics::State& state() const { return model_.state(); }
     const LoopStats&      stats() const { return stats_; }
 
 private:
     void step();
+    void dispatchScenarioEvents();
 
     SimConfig config_;
 
@@ -79,12 +87,16 @@ private:
     logging::ULogLogger     ulog_;
 
     std::array<double, physics::kNumMotors> motor_speeds_{};
+    std::array<bool, physics::kNumMotors>   locked_motors_{};
     std::atomic<bool> running_{false};
     LoopStats         stats_{};
     StatusServer      status_server_;
     uint64_t          hil_sensor_sent_{0};
     uint64_t          actuator_received_{0};
     float             last_baro_alt_m_{0.0f};
+
+    std::vector<ScenarioEvent> scenario_events_{};
+    std::size_t                scenario_idx_{0};
 };
 
 }  // namespace simuav

--- a/include/simuav/physics/WindModel.h
+++ b/include/simuav/physics/WindModel.h
@@ -39,6 +39,8 @@ public:
     // Call once per physics step. Returns wind velocity in NED (m/s).
     Eigen::Vector3d sample();
 
+    void setMeanNed(const Eigen::Vector3d& v) { params_.mean_ned = v; }
+
 private:
     Eigen::Vector3d drydenSample();
 

--- a/include/simuav/sensors/IMU.h
+++ b/include/simuav/sensors/IMU.h
@@ -36,6 +36,10 @@ public:
     IMUSample sample(const physics::State& state,
                      const Eigen::Vector3d& accel_world_ned);
 
+    // Adds a one-shot constant offset to the running bias vectors.
+    void injectBias(const Eigen::Vector3d& accel_offset,
+                    const Eigen::Vector3d& gyro_offset);
+
 private:
     IMUParams       params_;
     Eigen::Vector3d accel_bias_{Eigen::Vector3d::Zero()};

--- a/src/ScenarioLoader.cpp
+++ b/src/ScenarioLoader.cpp
@@ -1,0 +1,37 @@
+#include "simuav/ScenarioLoader.h"
+
+#include <algorithm>
+#include <fstream>
+#include <stdexcept>
+
+namespace simuav {
+
+std::vector<ScenarioEvent> loadScenario(const std::string& path) {
+    std::ifstream f(path);
+    if (!f.is_open())
+        throw std::runtime_error("ScenarioLoader: cannot open '" + path + "'");
+
+    const nlohmann::json j = nlohmann::json::parse(f);
+    if (!j.is_array())
+        throw std::runtime_error("ScenarioLoader: root element must be a JSON array");
+
+    std::vector<ScenarioEvent> events;
+    events.reserve(j.size());
+
+    for (const auto& item : j) {
+        ScenarioEvent ev;
+        ev.time_s = item.at("time_s").get<double>();
+        ev.type   = item.at("type").get<std::string>();
+        ev.params = item.value("params", nlohmann::json::object());
+        events.push_back(std::move(ev));
+    }
+
+    std::sort(events.begin(), events.end(),
+              [](const ScenarioEvent& a, const ScenarioEvent& b) {
+                  return a.time_s < b.time_s;
+              });
+
+    return events;
+}
+
+} // namespace simuav

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -32,6 +32,11 @@ Simulator::Simulator(SimConfig config)
     , status_server_(config_.status_port)
 {}
 
+void Simulator::loadScenario(const std::string& path) {
+    scenario_events_ = simuav::loadScenario(path);
+    scenario_idx_    = 0;
+}
+
 void Simulator::run() {
     if (!mavlink_.open()) {
         std::fprintf(stderr, "Simulator: failed to open MAVLink bridge\n");
@@ -108,23 +113,59 @@ void Simulator::stop() {
     running_ = false;
 }
 
+void Simulator::dispatchScenarioEvents() {
+    const double sim_time = model_.state().time;
+    while (scenario_idx_ < scenario_events_.size() &&
+           scenario_events_[scenario_idx_].time_s <= sim_time) {
+        const ScenarioEvent& ev = scenario_events_[scenario_idx_];
+        if (ev.type == "wind_mean") {
+            const auto& ned = ev.params.at("ned");
+            wind_.setMeanNed({ned[0].get<double>(),
+                              ned[1].get<double>(),
+                              ned[2].get<double>()});
+        } else if (ev.type == "motor_lock") {
+            const int m = ev.params.at("motor").get<int>();
+            if (m >= 0 && m < static_cast<int>(physics::kNumMotors))
+                locked_motors_[static_cast<std::size_t>(m)] = true;
+        } else if (ev.type == "imu_bias_inject") {
+            const auto& a = ev.params.at("accel");
+            const auto& g = ev.params.at("gyro");
+            imu_.injectBias(
+                {a[0].get<double>(), a[1].get<double>(), a[2].get<double>()},
+                {g[0].get<double>(), g[1].get<double>(), g[2].get<double>()}
+            );
+        } else if (ev.type == "stop") {
+            stop();
+        }
+        ++scenario_idx_;
+    }
+}
+
 void Simulator::step() {
     // 1. Pull actuator commands (non-blocking; keep last if none arrives)
     const std::array<double, physics::kNumMotors> prev = motor_speeds_;
     mavlink_.receiveActuators(motor_speeds_);
     if (motor_speeds_ != prev) ++actuator_received_;
 
-    // 2. Wind disturbance
+    // 2. Dispatch any scenario events due at this simulation time
+    dispatchScenarioEvents();
+
+    // 3. Apply locked motors before physics integration
+    for (std::size_t i = 0; i < physics::kNumMotors; ++i) {
+        if (locked_motors_[i]) motor_speeds_[i] = 0.0;
+    }
+
+    // 4. Wind disturbance
     const Eigen::Vector3d wind_ned = wind_.sample();
 
-    // 3. Physics integration
+    // 5. Physics integration
     model_.integrate(motor_speeds_, config_.dt, wind_ned);
     const physics::State& s = model_.state();
 
-    // 4. World-frame linear acceleration produced by the last physics step.
+    // 6. World-frame linear acceleration produced by the last physics step.
     const Eigen::Vector3d accel_world = model_.lastAccelWorld();
 
-    // 5. Sample sensors
+    // 7. Sample sensors
     const sensors::IMUSample  imu_s  = imu_.sample(s, accel_world);
     const sensors::BaroSample baro_s = baro_.sample(s);
     const sensors::MagSample  mag_s  = mag_.sample(s);
@@ -134,7 +175,7 @@ void Simulator::step() {
 
     last_baro_alt_m_ = baro_s.altitude_m;
 
-    // 6. Sample battery and send HIL messages
+    // 8. Sample battery and send HIL messages
     const sensors::BatterySample bat_s =
         battery_.sample(motor_speeds_, config_.quad_params, config_.dt);
 
@@ -143,7 +184,7 @@ void Simulator::step() {
     ++hil_sensor_sent_;
     if (new_gps) mavlink_.sendHilGps(gps_s);
 
-    // 7. Log
+    // 9. Log
     json_log_.log(s, imu_s, baro_s, gps_s);
     ulog_.log(s, imu_s, baro_s, gps_s);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,6 +22,7 @@ void onSignal(int) {
 int main(int argc, char* argv[]) {
     std::string config_path;
     std::string replay_path;
+    std::string scenario_path;
     int         status_port_override = -1; // -1 = not set on command line
 
     for (int i = 1; i < argc; ++i) {
@@ -38,6 +39,12 @@ int main(int argc, char* argv[]) {
                 return EXIT_FAILURE;
             }
             replay_path = argv[++i];
+        } else if (arg == "--scenario") {
+            if (i + 1 >= argc) {
+                std::fprintf(stderr, "--scenario requires a path argument\n");
+                return EXIT_FAILURE;
+            }
+            scenario_path = argv[++i];
         } else if (arg == "--status-port") {
             if (i + 1 >= argc) {
                 std::fprintf(stderr, "--status-port requires a port number\n");
@@ -100,6 +107,17 @@ int main(int argc, char* argv[]) {
 
     simuav::Simulator sim(cfg);
     g_sim = &sim;
+
+    if (!scenario_path.empty()) {
+        try {
+            sim.loadScenario(scenario_path);
+            std::printf("Scenario loaded from %s\n", scenario_path.c_str());
+        } catch (const std::exception& e) {
+            std::fprintf(stderr, "Error loading scenario '%s': %s\n",
+                         scenario_path.c_str(), e.what());
+            return EXIT_FAILURE;
+        }
+    }
 
     std::signal(SIGINT,  onSignal);
     std::signal(SIGTERM, onSignal);

--- a/src/sensors/IMU.cpp
+++ b/src/sensors/IMU.cpp
@@ -65,4 +65,10 @@ IMUSample IMU::sample(const physics::State& state,
     return out;
 }
 
+void IMU::injectBias(const Eigen::Vector3d& accel_offset,
+                     const Eigen::Vector3d& gyro_offset) {
+    accel_bias_ += accel_offset;
+    gyro_bias_  += gyro_offset;
+}
+
 }  // namespace simuav::sensors

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(simuav_tests
     test_simulator.cpp
     test_status.cpp
     test_frames.cpp
+    test_scenario.cpp
 )
 
 target_link_libraries(simuav_tests PRIVATE

--- a/tests/test_scenario.cpp
+++ b/tests/test_scenario.cpp
@@ -1,0 +1,69 @@
+#include "simuav/ScenarioLoader.h"
+
+#include <gtest/gtest.h>
+#include <fstream>
+#include <string>
+
+namespace {
+
+std::string writeTempScenario(const std::string& content) {
+    const std::string path = "/tmp/simuav_test_scenario.json";
+    std::ofstream f(path);
+    f << content;
+    return path;
+}
+
+} // namespace
+
+TEST(ScenarioLoader, ParsesWellFormedFile) {
+    const std::string path = writeTempScenario(R"([
+        {"time_s": 5.0,  "type": "wind_mean",      "params": {"ned": [2.0, 0.0, 0.0]}},
+        {"time_s": 1.0,  "type": "motor_lock",     "params": {"motor": 2}},
+        {"time_s": 10.0, "type": "imu_bias_inject","params": {"accel": [0.1, 0.0, 0.0], "gyro": [0.0, 0.0, 0.01]}},
+        {"time_s": 20.0, "type": "stop"}
+    ])");
+
+    const auto events = simuav::loadScenario(path);
+
+    ASSERT_EQ(events.size(), 4u);
+
+    // Sorted ascending by time_s
+    EXPECT_DOUBLE_EQ(events[0].time_s, 1.0);
+    EXPECT_EQ(events[0].type, "motor_lock");
+
+    EXPECT_DOUBLE_EQ(events[1].time_s, 5.0);
+    EXPECT_EQ(events[1].type, "wind_mean");
+
+    EXPECT_DOUBLE_EQ(events[2].time_s, 10.0);
+    EXPECT_EQ(events[2].type, "imu_bias_inject");
+
+    EXPECT_DOUBLE_EQ(events[3].time_s, 20.0);
+    EXPECT_EQ(events[3].type, "stop");
+}
+
+TEST(ScenarioLoader, ThrowsOnMissingFile) {
+    EXPECT_THROW(simuav::loadScenario("/tmp/__nonexistent_scenario__.json"),
+                 std::runtime_error);
+}
+
+TEST(ScenarioLoader, EmptyArrayIsNoOp) {
+    const std::string path = writeTempScenario("[]");
+    const auto events = simuav::loadScenario(path);
+    EXPECT_TRUE(events.empty());
+}
+
+TEST(ScenarioLoader, ThrowsOnNonArrayRoot) {
+    const std::string path = writeTempScenario(R"({"time_s": 1.0, "type": "stop"})");
+    EXPECT_THROW(simuav::loadScenario(path), std::runtime_error);
+}
+
+TEST(ScenarioLoader, EventsWithPastTimeFire) {
+    const std::string path = writeTempScenario(R"([
+        {"time_s": 0.0, "type": "motor_lock", "params": {"motor": 0}}
+    ])");
+    const auto events = simuav::loadScenario(path);
+
+    ASSERT_EQ(events.size(), 1u);
+    EXPECT_DOUBLE_EQ(events[0].time_s, 0.0);
+    EXPECT_EQ(events[0].type, "motor_lock");
+}


### PR DESCRIPTION
## Summary
- New `ScenarioLoader` parses a JSON array of timed events from a file
- Events sorted by `time_s`; dispatched in `Simulator::step()` when `time_s <= sim_time`
- Four supported event types: `wind_mean`, `motor_lock`, `imu_bias_inject`, `stop`
- `WindModel::setMeanNed()` and `IMU::injectBias()` added for runtime mutation
- `--scenario <path>` CLI flag wired in `main.cpp`

## Test plan
- [ ] `ScenarioLoader_ParsesWellFormedFile`: parses all 4 types, verifies sort order
- [ ] `ScenarioLoader_ThrowsOnMissingFile`: runtime_error on bad path
- [ ] `ScenarioLoader_EmptyArrayIsNoOp`: empty array returns empty vector
- [ ] `ScenarioLoader_ThrowsOnNonArrayRoot`: non-array JSON root throws
- [ ] `ScenarioLoader_EventsWithPastTimeFire`: `time_s=0` event is present after load
- [ ] All 76 unit tests pass

Closes #40