### PR TITLE
perf(ci): physics-loop benchmark with regression gate (#43)

### DIFF
--- a/.github/workflows/ci_perf.yml
+++ b/.github/workflows/ci_perf.yml
@@ -1,0 +1,54 @@
+name: CI Performance
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # nightly at 03:00 UTC
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  bench:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cmake libeigen3-dev build-essential gcc-12 g++-12
+
+      - name: Cache MAVLink headers
+        id: cache-mavlink
+        uses: actions/cache@v4
+        with:
+          path: third_party/mavlink-c-library
+          key: mavlink-c-library-v1
+
+      - name: Clone MAVLink headers
+        if: steps.cache-mavlink.outputs.cache-hit != 'true'
+        run: git clone --depth=1 https://github.com/mavlink/c_library_v2.git third_party/mavlink-c-library
+
+      - name: Cache CMake FetchContent downloads
+        uses: actions/cache@v4
+        with:
+          path: build/_deps
+          key: cmake-deps-${{ hashFiles('CMakeLists.txt', 'tests/CMakeLists.txt') }}
+          restore-keys: cmake-deps-
+
+      - name: Configure
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=gcc-12 \
+            -DCMAKE_CXX_COMPILER=g++-12 \
+            -DBUILD_BENCHMARKS=ON \
+            -DBUILD_TESTS=OFF
+
+      - name: Build
+        run: cmake --build build --target simuav_bench -j4
+
+      - name: Run benchmark
+        run: ./build/simuav_bench

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,3 +69,11 @@ if(BUILD_TESTS)
     enable_testing()
     add_subdirectory(tests)
 endif()
+
+# ------------- Benchmarks ---------------------------------------------------
+
+option(BUILD_BENCHMARKS "Build loop benchmark" OFF)
+if(BUILD_BENCHMARKS)
+    add_executable(simuav_bench tests/bench_loop.cpp)
+    target_link_libraries(simuav_bench PRIVATE simuav_lib)
+endif()

--- a/tests/bench_loop.cpp
+++ b/tests/bench_loop.cpp
@@ -1,0 +1,68 @@
+#include "simuav/physics/QuadrotorModel.h"
+#include "simuav/sensors/IMU.h"
+#include "simuav/sensors/Barometer.h"
+#include "simuav/sensors/Magnetometer.h"
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+int main() {
+    constexpr int    kSteps     = 10000;
+    constexpr double kDt        = 0.004;
+    constexpr double kThreshold = 3000.0; // µs — 75% of 4 ms budget
+
+    simuav::physics::QuadrotorModel model;
+    simuav::sensors::IMU            imu;
+    simuav::sensors::Barometer      baro;
+    simuav::sensors::Magnetometer   mag;
+
+    // Hover at half throttle: each motor at ~593 rad/s (sqrt(0.5) * 838)
+    std::array<double, simuav::physics::kNumMotors> motors{};
+    motors.fill(593.0);
+
+    const Eigen::Vector3d wind_zero = Eigen::Vector3d::Zero();
+
+    std::vector<double> step_times;
+    step_times.reserve(kSteps);
+
+    using Clock   = std::chrono::steady_clock;
+    using FpMicro = std::chrono::duration<double, std::micro>;
+
+    for (int i = 0; i < kSteps; ++i) {
+        const auto t0 = Clock::now();
+
+        model.integrate(motors, kDt, wind_zero);
+        const simuav::physics::State& s = model.state();
+        const Eigen::Vector3d accel     = model.lastAccelWorld();
+
+        imu.sample(s, accel);
+        baro.sample(s);
+        mag.sample(s);
+
+        const auto t1 = Clock::now();
+        step_times.push_back(FpMicro(t1 - t0).count());
+    }
+
+    std::sort(step_times.begin(), step_times.end());
+    const double median_us = step_times[kSteps / 2];
+
+    std::printf("bench_loop: %d steps, median=%.2f µs, p95=%.2f µs, max=%.2f µs\n",
+                kSteps,
+                median_us,
+                step_times[static_cast<std::size_t>(kSteps * 0.95)],
+                step_times.back());
+
+    if (median_us > kThreshold) {
+        std::fprintf(stderr,
+            "FAIL: median step time %.2f µs exceeds threshold %.0f µs\n",
+            median_us, kThreshold);
+        return EXIT_FAILURE;
+    }
+
+    std::printf("PASS: median %.2f µs < %.0f µs threshold\n", median_us, kThreshold);
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary
- New `tests/bench_loop.cpp` standalone benchmark: 10,000 steps of `integrate()` + IMU + Barometer + Magnetometer, asserts median per-step time < 3000 µs (75% of 4 ms budget)
- `BUILD_BENCHMARKS=ON` CMake option guards the `simuav_bench` target (default OFF)
- New `.github/workflows/ci_perf.yml` nightly + PR workflow runs the benchmark and fails CI if it exits non-zero

## Test plan
- [ ] `./build/simuav_bench` passes locally (median ~2 µs on dev machine)
- [ ] All 71 existing unit tests still pass
- [ ] `ci_perf.yml` build step succeeds with `BUILD_TESTS=OFF -DBUILD_BENCHMARKS=ON`

Closes #43