### PR TITLE
feat(simulator): configurable run_duration_s with automatic stop (closes #71)

### DIFF
--- a/include/simuav/ConfigLoader.inl
+++ b/include/simuav/ConfigLoader.inl
@@ -17,7 +17,8 @@ inline SimConfig loadConfig(const std::string& path) {
     cfg.mavlink_local_port  = j.value("mavlink_local_port",  cfg.mavlink_local_port);
     cfg.json_log_path       = j.value("json_log_path",       cfg.json_log_path);
     cfg.ulog_path      = j.value("ulog_path",      cfg.ulog_path);
-    cfg.status_port    = j.value("status_port",    cfg.status_port);
+    cfg.status_port      = j.value("status_port",      cfg.status_port);
+    cfg.run_duration_s   = j.value("run_duration_s",   cfg.run_duration_s);
 
     {
         const std::string ft = j.value("firmware_target", std::string("px4"));

--- a/include/simuav/Simulator.h
+++ b/include/simuav/Simulator.h
@@ -36,6 +36,7 @@ struct SimConfig {
     std::string    json_log_path{"telemetry.json"};
     std::string    ulog_path{"telemetry.ulg"};
     uint16_t       status_port{14562};         // UDP port for status datagrams (0 = disabled)
+    double         run_duration_s{0.0};       // s, stop after this sim-time (0 = run forever)
 
     physics::QuadrotorParams quad_params{};
     physics::WindParams      wind_params{};

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -102,6 +102,11 @@ void Simulator::run() {
             status_server_.publish(snap);
         }
 
+        if (config_.run_duration_s > 0.0 && model_.state().time >= config_.run_duration_s) {
+            running_ = false;
+            break;
+        }
+
         std::this_thread::sleep_until(next_wake);
         next_wake += step_dur;
     }

--- a/tests/test_simulator.cpp
+++ b/tests/test_simulator.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 #include "simuav/Simulator.h"
+#include <future>
+#include <chrono>
 
 // Build a minimal SimConfig that avoids opening real files or sockets.
 static simuav::SimConfig minimalConfig() {
@@ -33,4 +35,32 @@ TEST(LoopStats, StepCountIncrements) {
 TEST(LoopStats, MaxStepUsIsNonNegative) {
     simuav::Simulator sim(minimalConfig());
     EXPECT_GE(sim.stats().max_step_us, 0.0);
+}
+
+TEST(RunDuration, StopsAfterConfiguredSimTime) {
+    simuav::SimConfig cfg = minimalConfig();
+    cfg.run_duration_s     = 0.1;   // 25 steps at dt=0.004
+    cfg.status_port        = 0;     // no UDP status broadcast
+    cfg.mavlink_local_port = 0;     // OS picks a free ephemeral port
+
+    simuav::Simulator sim(cfg);
+
+    auto fut = std::async(std::launch::async, [&] { sim.run(); });
+    const auto status = fut.wait_for(std::chrono::seconds(5));
+
+    ASSERT_EQ(status, std::future_status::ready)
+        << "Simulator did not stop within 5 s wall time";
+
+    // run_duration_s / dt = 25 expected steps; allow ±2 for rounding
+    const double expected = cfg.run_duration_s / cfg.dt;
+    EXPECT_NEAR(static_cast<double>(sim.stats().step_count), expected, 2.0);
+}
+
+TEST(RunDuration, ZeroDurationRunsForever) {
+    // Verify default (0.0) does NOT stop on its own — we just check the flag
+    // is not prematurely set by inspecting stats before any run().
+    simuav::SimConfig cfg = minimalConfig();
+    EXPECT_DOUBLE_EQ(cfg.run_duration_s, 0.0);
+    simuav::Simulator sim(cfg);
+    EXPECT_EQ(sim.stats().step_count, 0u);
 }


### PR DESCRIPTION
## Summary
- Adds `SimConfig::run_duration_s` (default `0.0` = run forever, backward-compatible)
- When positive, the sim loop exits cleanly after `model_.state().time >= run_duration_s`
- Parsed from JSON config as `"run_duration_s"`

## Test plan
- [ ] `RunDuration_StopsAfterConfiguredSimTime`: `run_duration_s=0.1` → stops in ~25 steps (±2), completes in <5 s wall time
- [ ] `RunDuration_ZeroDurationRunsForever`: default `0.0` leaves step_count at 0 before `run()`
- [ ] All 85 tests pass

Closes #71