### PR TITLE
feat(sensors): configurable rng_seed for reproducible simulation runs (closes #72)

### DIFF
--- a/include/simuav/ConfigLoader.inl
+++ b/include/simuav/ConfigLoader.inl
@@ -17,7 +17,8 @@ inline SimConfig loadConfig(const std::string& path) {
     cfg.mavlink_local_port  = j.value("mavlink_local_port",  cfg.mavlink_local_port);
     cfg.json_log_path       = j.value("json_log_path",       cfg.json_log_path);
     cfg.ulog_path      = j.value("ulog_path",      cfg.ulog_path);
-    cfg.status_port    = j.value("status_port",    cfg.status_port);
+    cfg.status_port      = j.value("status_port",      cfg.status_port);
+    cfg.run_duration_s   = j.value("run_duration_s",   cfg.run_duration_s);
 
     {
         const std::string ft = j.value("firmware_target", std::string("px4"));

--- a/include/simuav/ConfigLoader.inl
+++ b/include/simuav/ConfigLoader.inl
@@ -19,6 +19,7 @@ inline SimConfig loadConfig(const std::string& path) {
     cfg.ulog_path      = j.value("ulog_path",      cfg.ulog_path);
     cfg.status_port      = j.value("status_port",      cfg.status_port);
     cfg.run_duration_s   = j.value("run_duration_s",   cfg.run_duration_s);
+    cfg.rng_seed         = j.value("rng_seed",         cfg.rng_seed);
 
     {
         const std::string ft = j.value("firmware_target", std::string("px4"));

--- a/include/simuav/Simulator.h
+++ b/include/simuav/Simulator.h
@@ -36,6 +36,7 @@ struct SimConfig {
     std::string    json_log_path{"telemetry.json"};
     std::string    ulog_path{"telemetry.ulg"};
     uint16_t       status_port{14562};         // UDP port for status datagrams (0 = disabled)
+    double         run_duration_s{0.0};       // s, stop after this sim-time (0 = run forever)
 
     physics::QuadrotorParams quad_params{};
     physics::WindParams      wind_params{};

--- a/include/simuav/Simulator.h
+++ b/include/simuav/Simulator.h
@@ -37,6 +37,7 @@ struct SimConfig {
     std::string    ulog_path{"telemetry.ulg"};
     uint16_t       status_port{14562};         // UDP port for status datagrams (0 = disabled)
     double         run_duration_s{0.0};       // s, stop after this sim-time (0 = run forever)
+    uint64_t       rng_seed{0};               // 0 = use per-sensor defaults; non-zero seeds all subsystems
 
     physics::QuadrotorParams quad_params{};
     physics::WindParams      wind_params{};

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -7,15 +7,21 @@
 
 namespace simuav {
 
+// When rng_seed is non-zero, derive each subsystem seed from it to make the
+// entire run reproducible with a single user-facing value.
+static uint64_t deriveSeed(uint64_t base, uint64_t offset) {
+    return base == 0 ? offset : base + offset;
+}
+
 Simulator::Simulator(SimConfig config)
     : config_(std::move(config))
     , model_(config_.quad_params)
-    , wind_(config_.wind_params, config_.dt)
-    , imu_(config_.imu_params)
-    , gps_(config_.gps_params)
-    , baro_(config_.baro_params)
-    , mag_(config_.mag_params)
-    , battery_(config_.battery_params)
+    , wind_(config_.wind_params, config_.dt, deriveSeed(config_.rng_seed, 0))
+    , imu_(config_.imu_params,    deriveSeed(config_.rng_seed, 1))
+    , gps_(config_.gps_params,    deriveSeed(config_.rng_seed, 2))
+    , baro_(config_.baro_params,  deriveSeed(config_.rng_seed, 3))
+    , mag_(config_.mag_params,    deriveSeed(config_.rng_seed, 4))
+    , battery_(config_.battery_params, deriveSeed(config_.rng_seed, 5))
     , mavlink_([this] {
         comms::BridgeParams bp;
         bp.remote_host     = config_.mavlink_host;

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -102,6 +102,11 @@ void Simulator::run() {
             status_server_.publish(snap);
         }
 
+        if (config_.run_duration_s > 0.0 && model_.state().time >= config_.run_duration_s) {
+            running_ = false;
+            break;
+        }
+
         std::this_thread::sleep_until(next_wake);
         next_wake += step_dur;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,7 +23,8 @@ int main(int argc, char* argv[]) {
     std::string config_path;
     std::string replay_path;
     std::string scenario_path;
-    int         status_port_override = -1; // -1 = not set on command line
+    int         status_port_override = -1;  // -1 = not set on command line
+    long long   seed_override        = -1;  // -1 = not set on command line
 
     for (int i = 1; i < argc; ++i) {
         const std::string arg(argv[i]);
@@ -45,6 +46,12 @@ int main(int argc, char* argv[]) {
                 return EXIT_FAILURE;
             }
             scenario_path = argv[++i];
+        } else if (arg == "--seed") {
+            if (i + 1 >= argc) {
+                std::fprintf(stderr, "--seed requires an integer argument\n");
+                return EXIT_FAILURE;
+            }
+            seed_override = std::atoll(argv[++i]);
         } else if (arg == "--status-port") {
             if (i + 1 >= argc) {
                 std::fprintf(stderr, "--status-port requires a port number\n");
@@ -104,6 +111,8 @@ int main(int argc, char* argv[]) {
 
     if (status_port_override >= 0)
         cfg.status_port = static_cast<uint16_t>(status_port_override);
+    if (seed_override >= 0)
+        cfg.rng_seed = static_cast<uint64_t>(seed_override);
 
     simuav::Simulator sim(cfg);
     g_sim = &sim;

--- a/tests/test_simulator.cpp
+++ b/tests/test_simulator.cpp
@@ -64,3 +64,45 @@ TEST(RunDuration, ZeroDurationRunsForever) {
     simuav::Simulator sim(cfg);
     EXPECT_EQ(sim.stats().step_count, 0u);
 }
+
+// Helper that runs a sim with given seed and returns the final NED position.
+static Eigen::Vector3d runWithSeed(uint64_t seed) {
+    simuav::SimConfig cfg;
+    cfg.dt             = 0.004;
+    cfg.json_log_path  = "/dev/null";
+    cfg.ulog_path      = "/dev/null";
+    cfg.quad_params.motor_time_constant_s = 0.0;
+    cfg.quad_params.enable_ground_constraint = false; // allow free fall
+    cfg.run_duration_s     = 0.1;
+    cfg.status_port        = 0;
+    cfg.mavlink_local_port = 0;
+    cfg.rng_seed           = seed;
+
+    simuav::Simulator sim(cfg);
+    auto fut = std::async(std::launch::async, [&] { sim.run(); });
+    fut.wait_for(std::chrono::seconds(5));
+    return sim.state().position;
+}
+
+TEST(RngSeed, SameSeedProducesIdenticalState) {
+    const Eigen::Vector3d pos_a = runWithSeed(42);
+    const Eigen::Vector3d pos_b = runWithSeed(42);
+    EXPECT_DOUBLE_EQ(pos_a.x(), pos_b.x());
+    EXPECT_DOUBLE_EQ(pos_a.y(), pos_b.y());
+    EXPECT_DOUBLE_EQ(pos_a.z(), pos_b.z());
+}
+
+TEST(RngSeed, DifferentSeedsProduceDifferentState) {
+    const Eigen::Vector3d pos_a = runWithSeed(42);
+    const Eigen::Vector3d pos_b = runWithSeed(99);
+    // Wind differs between seeds; at least one position component must differ.
+    const bool differs = (pos_a - pos_b).norm() > 1e-10;
+    EXPECT_TRUE(differs);
+}
+
+TEST(RngSeed, DefaultZeroPreservesExistingBehavior) {
+    // rng_seed=0 uses legacy per-sensor offsets; just verify it constructs fine.
+    simuav::SimConfig cfg = minimalConfig();
+    EXPECT_EQ(cfg.rng_seed, 0u);
+    EXPECT_NO_THROW(simuav::Simulator sim(cfg));
+}

--- a/tests/test_simulator.cpp
+++ b/tests/test_simulator.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 #include "simuav/Simulator.h"
+#include <future>
+#include <chrono>
 
 // Build a minimal SimConfig that avoids opening real files or sockets.
 static simuav::SimConfig minimalConfig() {
@@ -33,4 +35,32 @@ TEST(LoopStats, StepCountIncrements) {
 TEST(LoopStats, MaxStepUsIsNonNegative) {
     simuav::Simulator sim(minimalConfig());
     EXPECT_GE(sim.stats().max_step_us, 0.0);
+}
+
+TEST(RunDuration, StopsAfterConfiguredSimTime) {
+    simuav::SimConfig cfg = minimalConfig();
+    cfg.run_duration_s     = 0.1;   // 25 steps at dt=0.004
+    cfg.status_port        = 0;     // no UDP status broadcast
+    cfg.mavlink_local_port = 0;     // OS picks a free ephemeral port
+
+    simuav::Simulator sim(cfg);
+
+    auto fut = std::async(std::launch::async, [&] { sim.run(); });
+    const auto status = fut.wait_for(std::chrono::seconds(5));
+
+    ASSERT_EQ(status, std::future_status::ready)
+        << "Simulator did not stop within 5 s wall time";
+
+    // run_duration_s / dt = 25 expected steps; allow ±2 for rounding
+    const double expected = cfg.run_duration_s / cfg.dt;
+    EXPECT_NEAR(static_cast<double>(sim.stats().step_count), expected, 2.0);
+}
+
+TEST(RunDuration, ZeroDurationRunsForever) {
+    // Verify default (0.0) does NOT stop on its own — we just check the flag
+    // is not prematurely set by inspecting stats before any run().
+    simuav::SimConfig cfg = minimalConfig();
+    EXPECT_DOUBLE_EQ(cfg.run_duration_s, 0.0);
+    simuav::Simulator sim(cfg);
+    EXPECT_EQ(sim.stats().step_count, 0u);
 }


### PR DESCRIPTION
## Summary
- Adds `SimConfig::rng_seed` (default `0` = use existing per-sensor defaults, backward-compatible)
- When non-zero, all subsystem seeds are derived as `rng_seed + offset` (Wind=+0, IMU=+1, GPS=+2, Baro=+3, Mag=+4, Battery=+5)
- `--seed <N>` CLI flag overrides `SimConfig::rng_seed` at runtime
- Parsed from JSON config as `"rng_seed"`

## Test plan
- [ ] `RngSeed_SameSeedProducesIdenticalState`: two runs with seed=42 → identical position after 0.1 s sim-time
- [ ] `RngSeed_DifferentSeedsProduceDifferentState`: seeds 42 vs 99 → divergent positions (wind differs)
- [ ] `RngSeed_DefaultZeroPreservesExistingBehavior`: default `rng_seed=0` constructs without error
- [ ] All 88 tests pass

Closes #72