### PR TITLE
fix(ci): pin empy==3.3.4 to unblock nightly e2e (PX4 + ArduPilot)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,8 +89,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .venv
-          # v2: cache key bumped to force rebuild now that kconfiglib is required
-          key: pip-venv-${{ hashFiles('px4-autopilot/Tools/setup/requirements.txt') }}-v2
+          # v3: cache key bumped to force rebuild with empy==3.3.4 pinned
+          key: pip-venv-${{ hashFiles('px4-autopilot/Tools/setup/requirements.txt') }}-v3
           restore-keys: pip-venv-
 
       - name: Install PX4 Python requirements
@@ -100,6 +100,8 @@ jobs:
           # PX4 v1.14 requirements.txt uses this form; strip the suffix in-place.
           sed -i 's/>=\([0-9][0-9.]*\)\.\*/>=\1/g' px4-autopilot/Tools/setup/requirements.txt
           .venv/bin/pip install -r px4-autopilot/Tools/setup/requirements.txt
+          # empy 4.x removed RAW_OPT used by PX4 v1.14 build scripts; force 3.3.4.
+          .venv/bin/pip install 'empy==3.3.4'
           # kconfiglib provides the 'menuconfig' module required by PX4's
           # cmake/kconfig.cmake at SITL startup. It is not in requirements.txt
           # for v1.14.0 but is checked at cmake configure time.

--- a/.github/workflows/e2e_ardupilot.yml
+++ b/.github/workflows/e2e_ardupilot.yml
@@ -97,8 +97,10 @@ jobs:
           if [ ! -f ardupilot/build/sitl/bin/arducopter ]; then
             cd ardupilot
             python3 -m venv /tmp/waf-venv
-            # empy==3.3.4 is required by waf to process ArduPilot .h.in templates
+            # empy==3.3.4 is required by waf to process ArduPilot .h.in templates.
+            # Activate the venv so ./waf uses the interpreter that has empy.
             /tmp/waf-venv/bin/pip install -q future 'empy==3.3.4'
+            source /tmp/waf-venv/bin/activate
             ./waf configure --board sitl
             ./waf copter -j4
           else


### PR DESCRIPTION
## Summary

- **Root cause**: empy 4.x (released 2025-10) removed `RAW_OPT`, breaking PX4 v1.14 build scripts. The venv cache expired after 7 days of no access, so `pip install -r requirements.txt` pulled empy 4.2.1, causing `AttributeError: module 'em' has no attribute 'RAW_OPT'` during every build. Both PX4 and ArduPilot SITL e2e jobs have been failing nightly for 8 consecutive days.
- **PX4 fix**: force-install `empy==3.3.4` after `requirements.txt`; bump venv cache key to `v3` to evict the stale 4.x venv.
- **ArduPilot fix**: activate `/tmp/waf-venv` before calling `./waf` so the correct Python interpreter (with empy 3.3.4) handles template processing.

## Test plan

- [ ] Trigger both `E2E (PX4 SITL)` and `E2E (ArduPilot SITL)` via `workflow_dispatch` after merge and confirm green
- [ ] Verify `empy-3.3.4` appears in the pip install output (not 4.x)