### PR TITLE
feat(comms): compute GPS course-over-ground from velocity (closes #74)

### DIFF
--- a/src/comms/MAVLinkBridge.cpp
+++ b/src/comms/MAVLinkBridge.cpp
@@ -124,6 +124,13 @@ void MAVLinkBridge::sendHilGps(const sensors::GPSSample& gps) {
     const float ground_speed = std::sqrt(gps.velocity_n * gps.velocity_n +
                                           gps.velocity_e * gps.velocity_e);
 
+    // COG in centidegrees [0, 36000). Below 0.2 m/s the heading is undefined.
+    const uint16_t cog_cdeg = (ground_speed >= 0.2f)
+        ? static_cast<uint16_t>(std::fmod(
+              std::atan2(gps.velocity_e, gps.velocity_n) * (18000.0 / M_PI) + 36000.0,
+              36000.0))
+        : UINT16_MAX;
+
     mavlink_msg_hil_gps_pack(
         params_.system_id, params_.component_id, &msg,
         time_us,
@@ -135,7 +142,7 @@ void MAVLinkBridge::sendHilGps(const sensors::GPSSample& gps) {
         static_cast<int16_t>(gps.velocity_n * 100),
         static_cast<int16_t>(gps.velocity_e * 100),
         static_cast<int16_t>(gps.velocity_d * 100),
-        UINT16_MAX,  // course over ground (unknown)
+        cog_cdeg,
         gps.num_sats,
         0,          // id: single GPS instance
         UINT16_MAX  // yaw: unknown

--- a/tests/test_bridge.cpp
+++ b/tests/test_bridge.cpp
@@ -325,6 +325,70 @@ TEST_F(LoopbackFixture, SendHilGpsDeliversMavlinkPacket) {
     EXPECT_EQ(static_cast<uint16_t>(250), g.epv); // 2.5*100
     EXPECT_EQ(12u,                        g.satellites_visible);
     EXPECT_EQ(3u,                         g.fix_type);
+    // COG for vn=1, ve=2: atan2(2,1)*18000/pi + 0 ≈ 6343 centidegrees
+    const uint16_t expected_cog = static_cast<uint16_t>(
+        std::fmod(std::atan2(2.0, 1.0) * (18000.0 / M_PI) + 36000.0, 36000.0));
+    EXPECT_EQ(expected_cog, g.cog);
+}
+
+TEST_F(LoopbackFixture, HilGpsCogDueNorth) {
+    simuav::sensors::GPSSample gps{};
+    gps.fix_type    = 3;
+    gps.velocity_n  = 1.0f;
+    gps.velocity_e  = 0.0f;
+    gps.num_sats    = 6;
+
+    bridge_.sendHilGps(gps);
+
+    std::array<uint8_t, MAVLINK_MAX_PACKET_LEN> buf{};
+    sockaddr_in src{};
+    ASSERT_GT(recvWithTimeout(peer_fd_, buf.data(), buf.size(), &src, 250), 0);
+
+    mavlink_message_t msg{};
+    ASSERT_TRUE(parseMavlink(buf.data(), buf.size(), msg));
+    mavlink_hil_gps_t g{};
+    mavlink_msg_hil_gps_decode(&msg, &g);
+    EXPECT_EQ(0u, g.cog);  // due North = 0 centidegrees
+}
+
+TEST_F(LoopbackFixture, HilGpsCogDueEast) {
+    simuav::sensors::GPSSample gps{};
+    gps.fix_type    = 3;
+    gps.velocity_n  = 0.0f;
+    gps.velocity_e  = 1.0f;
+    gps.num_sats    = 6;
+
+    bridge_.sendHilGps(gps);
+
+    std::array<uint8_t, MAVLINK_MAX_PACKET_LEN> buf{};
+    sockaddr_in src{};
+    ASSERT_GT(recvWithTimeout(peer_fd_, buf.data(), buf.size(), &src, 250), 0);
+
+    mavlink_message_t msg{};
+    ASSERT_TRUE(parseMavlink(buf.data(), buf.size(), msg));
+    mavlink_hil_gps_t g{};
+    mavlink_msg_hil_gps_decode(&msg, &g);
+    EXPECT_EQ(9000u, g.cog);  // due East = 9000 centidegrees
+}
+
+TEST_F(LoopbackFixture, HilGpsCogUnknownBelowThreshold) {
+    simuav::sensors::GPSSample gps{};
+    gps.fix_type    = 3;
+    gps.velocity_n  = 0.1f;   // ground speed ~0.14 m/s, below 0.2 m/s threshold
+    gps.velocity_e  = 0.1f;
+    gps.num_sats    = 6;
+
+    bridge_.sendHilGps(gps);
+
+    std::array<uint8_t, MAVLINK_MAX_PACKET_LEN> buf{};
+    sockaddr_in src{};
+    ASSERT_GT(recvWithTimeout(peer_fd_, buf.data(), buf.size(), &src, 250), 0);
+
+    mavlink_message_t msg{};
+    ASSERT_TRUE(parseMavlink(buf.data(), buf.size(), msg));
+    mavlink_hil_gps_t g{};
+    mavlink_msg_hil_gps_decode(&msg, &g);
+    EXPECT_EQ(UINT16_MAX, g.cog);
 }
 
 TEST_F(LoopbackFixture, ReceiveActuatorsDecodesMotorSpeeds) {


### PR DESCRIPTION
## Summary

- Replaces hardcoded `UINT16_MAX` cog with `atan2(velocity_e, velocity_n)` converted to centidegrees `[0, 36000)`
- Below 0.2 m/s ground speed, heading is geometrically undefined — `UINT16_MAX` is kept per MAVLink convention
- Fixes EKF heading drift during flight-path accuracy tests caused by the firmware falling back to magnetometer heading

## Test plan

- [x] `HilGpsCogDueNorth` — vn=1, ve=0 → cog=0 cdeg
- [x] `HilGpsCogDueEast` — vn=0, ve=1 → cog=9000 cdeg
- [x] `HilGpsCogUnknownBelowThreshold` — speed ~0.14 m/s → cog=UINT16_MAX
- [x] Existing `SendHilGpsDeliversMavlinkPacket` updated and passing
- [x] Full suite: 86/86 pass