### PR TITLE
feat(scenario): add gps_fix_type, gps_noise_override, baro_noise_override events (closes #75)

### DIFF
--- a/include/simuav/sensors/Barometer.h
+++ b/include/simuav/sensors/Barometer.h
@@ -24,6 +24,9 @@ public:
 
     BaroSample sample(const physics::State& state);
 
+    // Runtime override — applied on the next sample() call.
+    void setNoiseStd(double std_m);
+
 private:
     BaroParams params_;
 

--- a/include/simuav/sensors/GPS.h
+++ b/include/simuav/sensors/GPS.h
@@ -39,6 +39,10 @@ public:
     // Returns false if it is not yet time for a new fix.
     bool sample(const physics::State& state, GPSSample& out);
 
+    // Runtime overrides — applied on the next sample() call.
+    void setFixType(uint8_t fix_type, uint8_t num_sats);
+    void setPosNoiseStd(double pos_std_m, double alt_std_m);
+
 private:
     GPSParams  params_;
     GPSSample  last_sample_;

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -147,6 +147,17 @@ void Simulator::dispatchScenarioEvents() {
             );
         } else if (ev.type == "stop") {
             stop();
+        } else if (ev.type == "gps_fix_type") {
+            const uint8_t ft   = static_cast<uint8_t>(ev.params.at("fix_type").get<int>());
+            const uint8_t sats = static_cast<uint8_t>(ev.params.at("num_sats").get<int>());
+            gps_.setFixType(ft, sats);
+        } else if (ev.type == "gps_noise_override") {
+            gps_.setPosNoiseStd(
+                ev.params.at("pos_std_m").get<double>(),
+                ev.params.at("alt_std_m").get<double>()
+            );
+        } else if (ev.type == "baro_noise_override") {
+            baro_.setNoiseStd(ev.params.at("noise_std_m").get<double>());
         }
         ++scenario_idx_;
     }

--- a/src/sensors/Barometer.cpp
+++ b/src/sensors/Barometer.cpp
@@ -27,4 +27,8 @@ BaroSample Barometer::sample(const physics::State& state) {
     return out;
 }
 
+void Barometer::setNoiseStd(double std_m) {
+    params_.noise_std_m = std_m;
+}
+
 }  // namespace simuav::sensors

--- a/src/sensors/GPS.cpp
+++ b/src/sensors/GPS.cpp
@@ -42,4 +42,14 @@ bool GPS::sample(const physics::State& state, GPSSample& out) {
     return true;
 }
 
+void GPS::setFixType(uint8_t fix_type, uint8_t num_sats) {
+    params_.fix_type = fix_type;
+    params_.num_sats = num_sats;
+}
+
+void GPS::setPosNoiseStd(double pos_std_m, double alt_std_m) {
+    params_.pos_noise_std_m = pos_std_m;
+    params_.alt_noise_std_m = alt_std_m;
+}
+
 }  // namespace simuav::sensors

--- a/tests/test_scenario.cpp
+++ b/tests/test_scenario.cpp
@@ -67,3 +67,34 @@ TEST(ScenarioLoader, EventsWithPastTimeFire) {
     EXPECT_DOUBLE_EQ(events[0].time_s, 0.0);
     EXPECT_EQ(events[0].type, "motor_lock");
 }
+
+TEST(ScenarioLoader, ParsesGpsFixTypeEvent) {
+    const std::string path = writeTempScenario(R"([
+        {"time_s": 5.0, "type": "gps_fix_type", "params": {"fix_type": 0, "num_sats": 0}}
+    ])");
+    const auto events = simuav::loadScenario(path);
+    ASSERT_EQ(events.size(), 1u);
+    EXPECT_EQ(events[0].type, "gps_fix_type");
+    EXPECT_EQ(events[0].params.at("fix_type").get<int>(), 0);
+    EXPECT_EQ(events[0].params.at("num_sats").get<int>(), 0);
+}
+
+TEST(ScenarioLoader, ParsesGpsNoiseOverrideEvent) {
+    const std::string path = writeTempScenario(R"([
+        {"time_s": 10.0, "type": "gps_noise_override", "params": {"pos_std_m": 50.0, "alt_std_m": 80.0}}
+    ])");
+    const auto events = simuav::loadScenario(path);
+    ASSERT_EQ(events.size(), 1u);
+    EXPECT_EQ(events[0].type, "gps_noise_override");
+    EXPECT_DOUBLE_EQ(events[0].params.at("pos_std_m").get<double>(), 50.0);
+}
+
+TEST(ScenarioLoader, ParsesBaroNoiseOverrideEvent) {
+    const std::string path = writeTempScenario(R"([
+        {"time_s": 15.0, "type": "baro_noise_override", "params": {"noise_std_m": 5.0}}
+    ])");
+    const auto events = simuav::loadScenario(path);
+    ASSERT_EQ(events.size(), 1u);
+    EXPECT_EQ(events[0].type, "baro_noise_override");
+    EXPECT_DOUBLE_EQ(events[0].params.at("noise_std_m").get<double>(), 5.0);
+}

--- a/tests/test_sensors.cpp
+++ b/tests/test_sensors.cpp
@@ -337,3 +337,58 @@ TEST(Battery, SoCClampedAtZero) {
     EXPECT_GE(s.remaining, 0.0);
     EXPECT_GE(s.voltage_v, 0.0);
 }
+
+TEST(GPS, SetFixTypeOverridesNextSample) {
+    simuav::sensors::GPSParams p;
+    p.update_rate_hz = 1000.0;  // always produce a new sample
+    simuav::sensors::GPS gps(p);
+
+    simuav::physics::State s;
+    simuav::sensors::GPSSample out;
+
+    gps.setFixType(0, 0);
+    s.time = 0.0;
+    gps.sample(s, out);
+    EXPECT_EQ(0u, out.fix_type);
+    EXPECT_EQ(0u, out.num_sats);
+
+    gps.setFixType(3, 12);
+    s.time = 1.0;
+    gps.sample(s, out);
+    EXPECT_EQ(3u, out.fix_type);
+    EXPECT_EQ(12u, out.num_sats);
+}
+
+TEST(GPS, SetPosNoiseStdOverridesEph) {
+    simuav::sensors::GPSParams p;
+    p.update_rate_hz = 1000.0;
+    simuav::sensors::GPS gps(p);
+
+    simuav::physics::State s;
+    simuav::sensors::GPSSample out;
+
+    gps.setPosNoiseStd(50.0, 80.0);
+    s.time = 0.0;
+    gps.sample(s, out);
+    EXPECT_FLOAT_EQ(50.0f, out.eph);
+    EXPECT_FLOAT_EQ(80.0f, out.epv);
+}
+
+TEST(Barometer, SetNoiseStdOverridesAltitudeNoise) {
+    simuav::sensors::BaroParams bp;
+    bp.noise_std_m = 0.0;  // start silent
+    simuav::sensors::Barometer baro(bp);
+
+    simuav::physics::State s;
+    s.position.z() = 0.0;  // at reference altitude
+
+    // With noise=0, altitude should equal reference.
+    auto sample0 = baro.sample(s);
+    EXPECT_NEAR(sample0.altitude_m, static_cast<float>(bp.alt_ref_m), 1e-3f);
+
+    // After override, noise is applied; we just check the setter doesn't crash
+    // and the baro still returns a finite value.
+    baro.setNoiseStd(5.0);
+    auto sample1 = baro.sample(s);
+    EXPECT_TRUE(std::isfinite(sample1.altitude_m));
+}


### PR DESCRIPTION
## Summary

- `GPS::setFixType(fix_type, num_sats)` — override reported GPS quality mid-run
- `GPS::setPosNoiseStd(pos_std_m, alt_std_m)` — override GPS position noise (also sets eph/epv)
- `Barometer::setNoiseStd(std_m)` — override barometric noise
- Three new scenario event types dispatched by `Simulator::dispatchScenarioEvents()`
- Unrecognised event types continue to be silently ignored

## Test plan

- [x] `GPS.SetFixTypeOverridesNextSample` — fix_type and num_sats change reflected in next sample
- [x] `GPS.SetPosNoiseStdOverridesEph` — eph/epv updated after override
- [x] `Barometer.SetNoiseStdOverridesAltitudeNoise` — setter applies, sample stays finite
- [x] 3 scenario parsing tests (gps_fix_type, gps_noise_override, baro_noise_override)
- [x] Full suite: 99/99 pass