### PR TITLE
feat(logging): record motor speeds, battery state, and wind vector (closes #76)

### DIFF
--- a/include/simuav/logging/JSONLogger.h
+++ b/include/simuav/logging/JSONLogger.h
@@ -4,7 +4,9 @@
 #include "simuav/sensors/GPS.h"
 #include "simuav/sensors/Barometer.h"
 #include "simuav/sensors/Magnetometer.h"
+#include "simuav/sensors/Battery.h"
 
+#include <array>
 #include <fstream>
 #include <string>
 
@@ -12,7 +14,8 @@ namespace simuav::logging {
 
 // Writes telemetry as newline-delimited JSON (NDJSON).
 // One JSON object per call to log(), flushed lazily.
-// Fields: t, pos[3], vel[3], att[4], omega[3], accel[3], gyro[3], baro_alt, gps_lat, gps_lon
+// Fields: t, pos[3], vel[3], att[4], omega[3], accel[3], gyro[3], baro_alt,
+//         gps_lat, gps_lon, motor_rad_s[4], bat_v, bat_soc, wind_ned[3]
 class JSONLogger {
 public:
     explicit JSONLogger(const std::string& path);
@@ -20,10 +23,13 @@ public:
 
     bool isOpen() const { return file_.is_open(); }
 
-    void log(const physics::State&      state,
-             const sensors::IMUSample&  imu,
-             const sensors::BaroSample& baro,
-             const sensors::GPSSample&  gps);
+    void log(const physics::State&                         state,
+             const sensors::IMUSample&                     imu,
+             const sensors::BaroSample&                    baro,
+             const sensors::GPSSample&                     gps,
+             const std::array<double, physics::kNumMotors>& motor_rad_s,
+             const sensors::BatterySample&                 bat,
+             const Eigen::Vector3d&                        wind_ned);
 
 private:
     std::ofstream file_;

--- a/include/simuav/logging/ULogLogger.h
+++ b/include/simuav/logging/ULogLogger.h
@@ -3,7 +3,9 @@
 #include "simuav/sensors/IMU.h"
 #include "simuav/sensors/GPS.h"
 #include "simuav/sensors/Barometer.h"
+#include "simuav/sensors/Battery.h"
 
+#include <array>
 #include <fstream>
 #include <string>
 #include <cstdint>
@@ -13,12 +15,13 @@ namespace simuav::logging {
 // Writes telemetry in PX4 uLog binary format.
 // Spec: https://docs.px4.io/main/en/dev_log/ulog_file_format.html
 //
-// Layout written:
-//   File header (16 bytes magic + timestamp)
-//   FLAG_BITS message
-//   FORMAT messages  (vehicle_local_position, vehicle_imu, vehicle_gps_position, vehicle_air_data)
-//   SUBSCRIPTION messages (one per FORMAT, msg_id 0-3)
-//   DATA messages   (one per log() call, msg_id 0 = vehicle_local_position)
+// Topics (msg_id order):
+//   0  vehicle_local_position
+//   1  vehicle_imu
+//   2  vehicle_gps_position
+//   3  vehicle_air_data
+//   4  vehicle_actuator_outputs   (motor speeds rad/s)
+//   5  vehicle_battery_status     (voltage, current, remaining)
 class ULogLogger {
 public:
     explicit ULogLogger(const std::string& path);
@@ -26,10 +29,12 @@ public:
 
     bool isOpen() const { return file_.is_open(); }
 
-    void log(const physics::State&      state,
-             const sensors::IMUSample&  imu,
-             const sensors::BaroSample& baro,
-             const sensors::GPSSample&  gps);
+    void log(const physics::State&                         state,
+             const sensors::IMUSample&                     imu,
+             const sensors::BaroSample&                    baro,
+             const sensors::GPSSample&                     gps,
+             const std::array<double, physics::kNumMotors>& motor_rad_s,
+             const sensors::BatterySample&                 bat);
 
 private:
     void writeFileHeader();

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -207,8 +207,8 @@ void Simulator::step() {
     if (new_gps) mavlink_.sendHilGps(gps_s);
 
     // 9. Log
-    json_log_.log(s, imu_s, baro_s, gps_s);
-    ulog_.log(s, imu_s, baro_s, gps_s);
+    json_log_.log(s, imu_s, baro_s, gps_s, model_.motorSpeedsActual(), bat_s, wind_ned);
+    ulog_.log(s, imu_s, baro_s, gps_s, model_.motorSpeedsActual(), bat_s);
 }
 
 }  // namespace simuav

--- a/src/logging/JSONLogger.cpp
+++ b/src/logging/JSONLogger.cpp
@@ -10,10 +10,13 @@ JSONLogger::~JSONLogger() {
     if (file_.is_open()) file_.close();
 }
 
-void JSONLogger::log(const physics::State&      state,
-                      const sensors::IMUSample&  imu,
-                      const sensors::BaroSample& baro,
-                      const sensors::GPSSample&  gps)
+void JSONLogger::log(const physics::State&                         state,
+                      const sensors::IMUSample&                     imu,
+                      const sensors::BaroSample&                    baro,
+                      const sensors::GPSSample&                     gps,
+                      const std::array<double, physics::kNumMotors>& motor_rad_s,
+                      const sensors::BatterySample&                 bat,
+                      const Eigen::Vector3d&                        wind_ned)
 {
     if (!file_.is_open()) return;
 
@@ -25,16 +28,23 @@ void JSONLogger::log(const physics::State&      state,
     const auto& g = imu.gyro_body;
 
     file_ << std::fixed << std::setprecision(6)
-          << "{\"t\":"        << state.time
-          << ",\"pos\":["     << p.x() << ',' << p.y() << ',' << p.z() << ']'
-          << ",\"vel\":["     << v.x() << ',' << v.y() << ',' << v.z() << ']'
-          << ",\"att\":["     << q.w() << ',' << q.x() << ',' << q.y() << ',' << q.z() << ']'
-          << ",\"omega\":["   << w.x() << ',' << w.y() << ',' << w.z() << ']'
-          << ",\"accel\":["   << a.x() << ',' << a.y() << ',' << a.z() << ']'
-          << ",\"gyro\":["    << g.x() << ',' << g.y() << ',' << g.z() << ']'
-          << ",\"baro_alt\":" << baro.altitude_m
-          << ",\"gps_lat\":"  << std::setprecision(9) << gps.latitude_deg
-          << ",\"gps_lon\":"  << gps.longitude_deg
+          << "{\"t\":"            << state.time
+          << ",\"pos\":["         << p.x() << ',' << p.y() << ',' << p.z() << ']'
+          << ",\"vel\":["         << v.x() << ',' << v.y() << ',' << v.z() << ']'
+          << ",\"att\":["         << q.w() << ',' << q.x() << ',' << q.y() << ',' << q.z() << ']'
+          << ",\"omega\":["       << w.x() << ',' << w.y() << ',' << w.z() << ']'
+          << ",\"accel\":["       << a.x() << ',' << a.y() << ',' << a.z() << ']'
+          << ",\"gyro\":["        << g.x() << ',' << g.y() << ',' << g.z() << ']'
+          << ",\"baro_alt\":"     << baro.altitude_m
+          << ",\"gps_lat\":"      << std::setprecision(9) << gps.latitude_deg
+          << ",\"gps_lon\":"      << gps.longitude_deg
+          << std::setprecision(6)
+          << ",\"motor_rad_s\":["
+          << motor_rad_s[0] << ',' << motor_rad_s[1] << ','
+          << motor_rad_s[2] << ',' << motor_rad_s[3] << ']'
+          << ",\"bat_v\":"        << bat.voltage_v
+          << ",\"bat_soc\":"      << bat.remaining
+          << ",\"wind_ned\":["    << wind_ned.x() << ',' << wind_ned.y() << ',' << wind_ned.z() << ']'
           << "}\n";
 }
 

--- a/src/logging/ULogLogger.cpp
+++ b/src/logging/ULogLogger.cpp
@@ -13,11 +13,13 @@ static constexpr uint8_t kMsgFlagBits = 0x42; // 'B'
 static constexpr uint8_t kMsgFormat   = 0x46; // 'F'
 static constexpr uint8_t kMsgData     = 0x44; // 'D'
 
-static constexpr uint8_t  kMsgSubscription = 0x53;
-static constexpr uint16_t kMsgIdLocalPos   = 0;
-static constexpr uint16_t kMsgIdImu        = 1;
-static constexpr uint16_t kMsgIdGps        = 2;
-static constexpr uint16_t kMsgIdAirData    = 3;
+static constexpr uint8_t  kMsgSubscription    = 0x53;
+static constexpr uint16_t kMsgIdLocalPos      = 0;
+static constexpr uint16_t kMsgIdImu           = 1;
+static constexpr uint16_t kMsgIdGps           = 2;
+static constexpr uint16_t kMsgIdAirData       = 3;
+static constexpr uint16_t kMsgIdActuatorOut   = 4;
+static constexpr uint16_t kMsgIdBatteryStatus = 5;
 
 // vehicle_local_position fields logged (subset)
 static constexpr char kFormatLocalPos[] =
@@ -39,6 +41,14 @@ static constexpr char kFormatGps[] =
 static constexpr char kFormatAirData[] =
     "vehicle_air_data:uint64_t timestamp;"
     "float pressure_pa;float altitude_m;float temperature_c;";
+
+static constexpr char kFormatActuatorOut[] =
+    "vehicle_actuator_outputs:uint64_t timestamp;"
+    "float output[4];";
+
+static constexpr char kFormatBatteryStatus[] =
+    "vehicle_battery_status:uint64_t timestamp;"
+    "float voltage_v;float current_a;float remaining;";
 
 ULogLogger::ULogLogger(const std::string& path)
     : file_(path, std::ios::out | std::ios::binary | std::ios::trunc) {}
@@ -103,10 +113,12 @@ void ULogLogger::writeSubscriptionMessage(const char* topic_name, uint16_t msg_i
     writeBytes(topic_name, name_len);
 }
 
-void ULogLogger::log(const physics::State&      state,
-                      const sensors::IMUSample&  imu,
-                      const sensors::BaroSample& baro,
-                      const sensors::GPSSample&  gps)
+void ULogLogger::log(const physics::State&                         state,
+                      const sensors::IMUSample&                     imu,
+                      const sensors::BaroSample&                    baro,
+                      const sensors::GPSSample&                     gps,
+                      const std::array<double, physics::kNumMotors>& motor_rad_s,
+                      const sensors::BatterySample&                 bat)
 {
     if (!file_.is_open()) return;
 
@@ -117,10 +129,14 @@ void ULogLogger::log(const physics::State&      state,
         writeFormatMessage(kFormatImu);
         writeFormatMessage(kFormatGps);
         writeFormatMessage(kFormatAirData);
-        writeSubscriptionMessage("vehicle_local_position", kMsgIdLocalPos);
-        writeSubscriptionMessage("vehicle_imu",            kMsgIdImu);
-        writeSubscriptionMessage("vehicle_gps_position",   kMsgIdGps);
-        writeSubscriptionMessage("vehicle_air_data",       kMsgIdAirData);
+        writeFormatMessage(kFormatActuatorOut);
+        writeFormatMessage(kFormatBatteryStatus);
+        writeSubscriptionMessage("vehicle_local_position",    kMsgIdLocalPos);
+        writeSubscriptionMessage("vehicle_imu",               kMsgIdImu);
+        writeSubscriptionMessage("vehicle_gps_position",      kMsgIdGps);
+        writeSubscriptionMessage("vehicle_air_data",          kMsgIdAirData);
+        writeSubscriptionMessage("vehicle_actuator_outputs",  kMsgIdActuatorOut);
+        writeSubscriptionMessage("vehicle_battery_status",    kMsgIdBatteryStatus);
         header_written_ = true;
     }
 
@@ -216,6 +232,41 @@ void ULogLogger::log(const physics::State&      state,
         pl.pressure_pa = baro.pressure_pa;
         pl.altitude_m  = baro.altitude_m;
         pl.temperature_c = baro.temperature_c;
+        writeU16(static_cast<uint16_t>(sizeof(pl) + 1));
+        writeByte(kMsgData);
+        writeBytes(&pl, sizeof(pl));
+    }
+
+    {
+        struct __attribute__((packed)) ActuatorOutPayload {
+            uint16_t msg_id;
+            uint64_t timestamp;
+            float    output[4];
+        };
+        ActuatorOutPayload pl{};
+        pl.msg_id    = kMsgIdActuatorOut;
+        pl.timestamp = timestamp_us;
+        for (int i = 0; i < physics::kNumMotors; ++i)
+            pl.output[i] = static_cast<float>(motor_rad_s[static_cast<std::size_t>(i)]);
+        writeU16(static_cast<uint16_t>(sizeof(pl) + 1));
+        writeByte(kMsgData);
+        writeBytes(&pl, sizeof(pl));
+    }
+
+    {
+        struct __attribute__((packed)) BatteryPayload {
+            uint16_t msg_id;
+            uint64_t timestamp;
+            float    voltage_v;
+            float    current_a;
+            float    remaining;
+        };
+        BatteryPayload pl{};
+        pl.msg_id    = kMsgIdBatteryStatus;
+        pl.timestamp = timestamp_us;
+        pl.voltage_v = bat.voltage_v;
+        pl.current_a = bat.current_a;
+        pl.remaining = static_cast<float>(bat.remaining);
         writeU16(static_cast<uint16_t>(sizeof(pl) + 1));
         writeByte(kMsgData);
         writeBytes(&pl, sizeof(pl));

--- a/tests/test_ulog.cpp
+++ b/tests/test_ulog.cpp
@@ -9,8 +9,20 @@
 #include "simuav/logging/ULogLogger.h"
 #include "simuav/physics/QuadrotorModel.h"
 #include "simuav/sensors/Barometer.h"
+#include "simuav/sensors/Battery.h"
 #include "simuav/sensors/GPS.h"
 #include "simuav/sensors/IMU.h"
+
+static const std::array<double, simuav::physics::kNumMotors> kZeroMotors{};
+static const simuav::sensors::BatterySample kZeroBat{};
+
+static void writeTestEntry(simuav::logging::ULogLogger& logger,
+                           const simuav::physics::State& state) {
+    simuav::sensors::IMUSample  imu;
+    simuav::sensors::BaroSample baro{};
+    simuav::sensors::GPSSample  gps{};
+    logger.log(state, imu, baro, gps, kZeroMotors, kZeroBat);
+}
 
 // ── helpers ──────────────────────────────────────────────────────────────────
 
@@ -46,11 +58,7 @@ TEST(ULogLogger, SubscriptionMessagesPresent) {
         ASSERT_TRUE(logger.isOpen());
 
         simuav::physics::State state;          // Eigen members initialise to zero/identity
-        simuav::sensors::IMUSample imu;        // Eigen members initialise to zero
-        simuav::sensors::BaroSample baro{};    // POD aggregate — zero by value-init
-        simuav::sensors::GPSSample  gps{};     // POD aggregate — zero by value-init
-
-        logger.log(state, imu, baro, gps);
+        writeTestEntry(logger, state);
     }  // destructor flushes and closes
 
     // 2. Open for binary reading.
@@ -69,15 +77,15 @@ TEST(ULogLogger, SubscriptionMessagesPresent) {
         skipBytes(f, static_cast<std::size_t>(msg_size) - 1);
     }
 
-    // 5. Expect exactly 4 FORMAT messages (msg_type == 0x46 'F').
-    for (int i = 0; i < 4; ++i) {
+    // 5. Expect exactly 6 FORMAT messages (msg_type == 0x46 'F').
+    for (int i = 0; i < 6; ++i) {
         uint16_t msg_size = readU16(f);
         uint8_t  msg_type = readU8(f);
         ASSERT_EQ(0x46, msg_type) << "FORMAT message " << i << " has wrong type";
         skipBytes(f, static_cast<std::size_t>(msg_size) - 1);
     }
 
-    // 6. Expect exactly 4 SUBSCRIPTION messages (msg_type == 0x53 'S').
+    // 6. Expect exactly 6 SUBSCRIPTION messages (msg_type == 0x53 'S').
     //    Layout after the 2-byte msg_size:
     //      [0]      msg_type  (1 byte, == 0x53)
     //      [1]      multi_id  (1 byte, == 0)
@@ -89,14 +97,16 @@ TEST(ULogLogger, SubscriptionMessagesPresent) {
         const char* name;
     };
 
-    const std::array<ExpectedSub, 4> expected{{
+    const std::array<ExpectedSub, 6> expected{{
         {0, "vehicle_local_position"},
         {1, "vehicle_imu"},
         {2, "vehicle_gps_position"},
         {3, "vehicle_air_data"},
+        {4, "vehicle_actuator_outputs"},
+        {5, "vehicle_battery_status"},
     }};
 
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < 6; ++i) {
         uint16_t msg_size = readU16(f);
         uint8_t  msg_type = readU8(f);
         ASSERT_EQ(0x53, msg_type) << "SUBSCRIPTION message " << i << " has wrong type";
@@ -126,11 +136,7 @@ TEST(ULogLogger, AllFourTopicsHaveDataMessages) {
         ASSERT_TRUE(logger.isOpen());
 
         simuav::physics::State      state;
-        simuav::sensors::IMUSample  imu;
-        simuav::sensors::BaroSample baro{};
-        simuav::sensors::GPSSample  gps{};
-
-        logger.log(state, imu, baro, gps);
+        writeTestEntry(logger, state);
     }
 
     std::ifstream f(path, std::ios::binary);
@@ -145,20 +151,20 @@ TEST(ULogLogger, AllFourTopicsHaveDataMessages) {
         skipBytes(f, sz);
     }
 
-    // Skip 4 FORMAT messages.
-    for (int i = 0; i < 4; ++i) {
+    // Skip 6 FORMAT messages.
+    for (int i = 0; i < 6; ++i) {
         uint16_t sz = readU16(f);
         skipBytes(f, sz);
     }
 
-    // Skip 4 SUBSCRIPTION messages.
-    for (int i = 0; i < 4; ++i) {
+    // Skip 6 SUBSCRIPTION messages.
+    for (int i = 0; i < 6; ++i) {
         uint16_t sz = readU16(f);
         skipBytes(f, sz);
     }
 
     // Collect msg_ids from all DATA messages (msg_type == 0x44 'D').
-    std::array<bool, 4> seen{};
+    std::array<bool, 6> seen{};
     while (f) {
         uint16_t msg_size = readU16(f);
         if (!f) break;
@@ -167,8 +173,7 @@ TEST(ULogLogger, AllFourTopicsHaveDataMessages) {
 
         if (msg_type == 0x44) {
             uint16_t msg_id = readU16(f);
-            if (msg_id < 4) seen[msg_id] = true;
-            // Skip remaining payload bytes (msg_size - 1 type - 2 msg_id).
+            if (msg_id < 6) seen[msg_id] = true;
             skipBytes(f, static_cast<std::size_t>(msg_size) - 1 - 2);
         } else {
             skipBytes(f, static_cast<std::size_t>(msg_size) - 1);
@@ -179,6 +184,8 @@ TEST(ULogLogger, AllFourTopicsHaveDataMessages) {
     EXPECT_TRUE(seen[1]) << "DATA msg_id 1 (vehicle_imu) missing";
     EXPECT_TRUE(seen[2]) << "DATA msg_id 2 (vehicle_gps_position) missing";
     EXPECT_TRUE(seen[3]) << "DATA msg_id 3 (vehicle_air_data) missing";
+    EXPECT_TRUE(seen[4]) << "DATA msg_id 4 (vehicle_actuator_outputs) missing";
+    EXPECT_TRUE(seen[5]) << "DATA msg_id 5 (vehicle_battery_status) missing";
 }
 
 TEST(ULogLogger, FormatStringsContainTimestampFirstField) {
@@ -188,10 +195,7 @@ TEST(ULogLogger, FormatStringsContainTimestampFirstField) {
     {
         simuav::logging::ULogLogger logger(path);
         simuav::physics::State      state;
-        simuav::sensors::IMUSample  imu;
-        simuav::sensors::BaroSample baro{};
-        simuav::sensors::GPSSample  gps{};
-        logger.log(state, imu, baro, gps);
+        writeTestEntry(logger, state);
     }
 
     std::ifstream f(path, std::ios::binary);
@@ -202,7 +206,7 @@ TEST(ULogLogger, FormatStringsContainTimestampFirstField) {
     { uint16_t sz = readU16(f); skipBytes(f, sz); }
 
     int fmt_with_timestamp = 0;
-    for (int i = 0; i < 4; ++i) {
+    for (int i = 0; i < 6; ++i) {
         uint16_t msg_size = readU16(f);
         uint8_t  msg_type = readU8(f);
         ASSERT_EQ(0x46, msg_type);
@@ -218,7 +222,7 @@ TEST(ULogLogger, FormatStringsContainTimestampFirstField) {
             << "FORMAT " << i << " first field is not 'uint64_t timestamp': " << body;
         ++fmt_with_timestamp;
     }
-    EXPECT_EQ(4, fmt_with_timestamp);
+    EXPECT_EQ(6, fmt_with_timestamp);
 }
 
 TEST(ULogLogger, DataTimestampMatchesStateTime) {
@@ -229,22 +233,19 @@ TEST(ULogLogger, DataTimestampMatchesStateTime) {
     constexpr double kTime2 = 3.25;
     {
         simuav::logging::ULogLogger logger(path);
-        simuav::physics::State      state;
-        simuav::sensors::IMUSample  imu;
-        simuav::sensors::BaroSample baro{};
-        simuav::sensors::GPSSample  gps{};
+        simuav::physics::State state;
         state.time = kTime1;
-        logger.log(state, imu, baro, gps);
+        writeTestEntry(logger, state);
         state.time = kTime2;
-        logger.log(state, imu, baro, gps);
+        writeTestEntry(logger, state);
     }
 
     std::ifstream f(path, std::ios::binary);
     ASSERT_TRUE(f.is_open());
     skipBytes(f, 16);
     { uint16_t sz = readU16(f); skipBytes(f, sz); }       // FLAG_BITS
-    for (int i = 0; i < 4; ++i) { uint16_t sz = readU16(f); skipBytes(f, sz); } // FORMATs
-    for (int i = 0; i < 4; ++i) { uint16_t sz = readU16(f); skipBytes(f, sz); } // SUBs
+    for (int i = 0; i < 6; ++i) { uint16_t sz = readU16(f); skipBytes(f, sz); } // FORMATs
+    for (int i = 0; i < 6; ++i) { uint16_t sz = readU16(f); skipBytes(f, sz); } // SUBs
 
     // First DATA message (local_position, msg_id 0) written for kTime1.
     {


### PR DESCRIPTION
## Summary

- **JSONLogger**: adds `motor_rad_s[4]`, `bat_v`, `bat_soc`, `wind_ned[3]` fields per NDJSON line
- **ULogLogger**: adds `vehicle_actuator_outputs` (msg_id 4, 4×float motor speeds) and `vehicle_battery_status` (msg_id 5, voltage/current/remaining) topics with proper FORMAT + SUBSCRIPTION + DATA messages
- `Simulator::step()` passes `motorSpeedsActual()`, `bat_s`, and `wind_ned` to both loggers

## Test plan

- [x] uLog subscription test updated to verify 6 topics (4 original + 2 new)
- [x] `AllFourTopicsHaveDataMessages` extended to check msg_ids 4 and 5
- [x] `FormatStringsContainTimestampFirstField` extended to check all 6 FORMAT strings
- [x] Full suite: 99/99 pass