### PR TITLE
feat(comms): send MAVLink HEARTBEAT at 1 Hz to prevent HIL session timeout (closes #78)

### DIFF
--- a/include/simuav/comms/MAVLinkBridge.h
+++ b/include/simuav/comms/MAVLinkBridge.h
@@ -56,6 +56,9 @@ public:
     // Sends MAVLink BATTERY_STATUS (msg 147) with voltage, current, and SoC.
     void sendBatteryStatus(const sensors::BatterySample& bat);
 
+    // Sends MAVLink HEARTBEAT at 1 Hz so firmware does not drop the HIL session.
+    void sendHeartbeat();
+
     // Drains the receive buffer. Returns true if new actuator data was read.
     // out_speeds: motor angular speeds in rad/s (indices match QuadrotorModel).
     bool receiveActuators(std::array<double, 4>& out_speeds);

--- a/src/Simulator.cpp
+++ b/src/Simulator.cpp
@@ -96,7 +96,10 @@ void Simulator::run() {
             }
         }
 
-        // Publish status at ~1 Hz (every 250 steps)
+        // Heartbeat + status at ~1 Hz (every 250 steps at 250 Hz)
+        if (stats_.step_count % 250 == 0) {
+            mavlink_.sendHeartbeat();
+        }
         if (stats_.step_count % 250 == 0 && config_.status_port != 0) {
             StatusSnapshot snap;
             snap.sim_time          = model_.state().time;

--- a/src/comms/MAVLinkBridge.cpp
+++ b/src/comms/MAVLinkBridge.cpp
@@ -237,6 +237,17 @@ bool MAVLinkBridge::receiveActuators(std::array<double, 4>& out_speeds) {
     return got_actuators;
 }
 
+void MAVLinkBridge::sendHeartbeat() {
+    mavlink_message_t msg{};
+    mavlink_msg_heartbeat_pack(
+        params_.system_id, params_.component_id, &msg,
+        MAV_TYPE_GCS,        // we present as a GCS to keep the HIL session alive
+        MAV_AUTOPILOT_INVALID,
+        0, 0, 0              // base_mode, custom_mode, system_status
+    );
+    sendMessage(msg);
+}
+
 double MAVLinkBridge::escToSpeed(double throttle, double max_motor_speed,
                                   double motor_spin_min, double exponent) {
     const double t = std::max(0.0, std::min(1.0, throttle));

--- a/tests/test_bridge.cpp
+++ b/tests/test_bridge.cpp
@@ -417,3 +417,21 @@ TEST_F(LoopbackFixture, ReceiveActuatorsDecodesMotorSpeeds) {
     EXPECT_NEAR(speeds[2], 0.75 * 838.0, 1e-6);
     EXPECT_NEAR(speeds[3], 1.00 * 838.0, 1e-6);
 }
+
+TEST_F(LoopbackFixture, SendHeartbeatDeliversMavlinkPacket) {
+    bridge_.sendHeartbeat();
+
+    std::array<uint8_t, MAVLINK_MAX_PACKET_LEN> buf{};
+    sockaddr_in src{};
+    ASSERT_GT(recvWithTimeout(peer_fd_, buf.data(), buf.size(), &src, 250), 0)
+        << "HEARTBEAT datagram not received within 250 ms";
+
+    mavlink_message_t msg{};
+    ASSERT_TRUE(parseMavlink(buf.data(), buf.size(), msg));
+    EXPECT_EQ(static_cast<uint32_t>(MAVLINK_MSG_ID_HEARTBEAT), msg.msgid);
+
+    mavlink_heartbeat_t hb{};
+    mavlink_msg_heartbeat_decode(&msg, &hb);
+    EXPECT_EQ(static_cast<uint8_t>(MAV_TYPE_GCS), hb.type);
+    EXPECT_EQ(static_cast<uint8_t>(MAV_AUTOPILOT_INVALID), hb.autopilot);
+}


### PR DESCRIPTION
## Summary

- `MAVLinkBridge::sendHeartbeat()` packs `MAV_TYPE_GCS`/`MAV_AUTOPILOT_INVALID` HEARTBEAT
- Called every 250 steps (1 Hz) in the simulation loop, same cadence as the status server
- Prevents PX4/ArduPilot watchdog from dropping the HIL session during idle periods

## Test plan

- [x] `SendHeartbeatDeliversMavlinkPacket` — loopback verifies `MAVLINK_MSG_ID_HEARTBEAT`, `MAV_TYPE_GCS`, `MAV_AUTOPILOT_INVALID`
- [x] Full suite: 100/100 pass