### PR TITLE
fix(ci): repair nightly E2E build failures (PX4 IndexError + ArduPilot pexpect)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,6 +78,12 @@ jobs:
           git clone --depth=1 --branch v1.14.0 \
             https://github.com/PX4/PX4-Autopilot.git px4-autopilot
           cd px4-autopilot
+          # Annotated tags in shallow clones are tag objects, not commits, so
+          # git describe --match 'v[0-9]*' cannot resolve them and returns a
+          # bare hash, which makes px_update_git_header.py crash with IndexError.
+          # Replace the annotated tag with a lightweight tag at HEAD.
+          git tag -d v1.14.0 2>/dev/null || true
+          git tag v1.14.0
           git submodule update --init --recursive --depth=1
 
       # Use a venv to avoid PEP 668 "externally-managed-environment" errors

--- a/.github/workflows/e2e_ardupilot.yml
+++ b/.github/workflows/e2e_ardupilot.yml
@@ -97,9 +97,9 @@ jobs:
           if [ ! -f ardupilot/build/sitl/bin/arducopter ]; then
             cd ardupilot
             python3 -m venv /tmp/waf-venv
-            # empy==3.3.4 is required by waf to process ArduPilot .h.in templates.
-            # Activate the venv so ./waf uses the interpreter that has empy.
-            /tmp/waf-venv/bin/pip install -q future 'empy==3.3.4'
+            # empy==3.3.4: waf uses it to process .h.in templates.
+            # pexpect: required by waf's task scanner at configure time.
+            /tmp/waf-venv/bin/pip install -q future 'empy==3.3.4' pexpect
             source /tmp/waf-venv/bin/activate
             ./waf configure --board sitl
             ./waf copter -j4


### PR DESCRIPTION
## Summary

- **PX4 SITL**: `px_update_git_header.py` crashed with `IndexError: list index out of range` because `git clone --depth=1 --branch v1.14.0` stores the annotated tag as a tag object (not a commit), so `git describe --match 'v[0-9]*'` falls back to a bare commit hash that the version parser can't split into major/minor/patch components. Fix: delete the annotated tag immediately after clone and recreate it as a lightweight tag at HEAD.
- **ArduPilot SITL**: waf's configure step aborted with `you need to install pexpect` because `pexpect` is scanned at configure time but was not in the waf venv. Fix: add `pexpect` to the `pip install` line in the build step.

## Test plan

- [ ] Trigger the E2E (PX4 SITL) workflow manually after merge and confirm the "Build PX4 SITL binary" step passes
- [ ] Trigger the E2E (ArduPilot SITL) workflow manually after merge and confirm the "Build ArduCopter SITL binary" step passes
- [ ] Verify CI (unit tests) continues to pass on this PR