### PR TITLE
fix(ci): add pexpect to ArduPilot E2E runtime venv + capture SITL stderr

### DIFF
--- a/.github/workflows/e2e_ardupilot.yml
+++ b/.github/workflows/e2e_ardupilot.yml
@@ -81,13 +81,13 @@ jobs:
           # ArduCopter-4.5 has no requirements.txt at the repo root.
           # Only pymavlink is needed for our e2e script; pin the key to a
           # static version so the cache rebuilds only when explicitly bumped.
-          key: pip-venv-ap-v2-${{ runner.os }}
+          # v3: added pexpect — sim_vehicle.py imports it at startup.
+          key: pip-venv-ap-v3-${{ runner.os }}
           restore-keys: pip-venv-ap-
 
       - name: Install Python packages
-        # sim_vehicle.py and our e2e script only need pymavlink and future.
-        # ArduCopter-4.5 has no root-level requirements.txt.
-        run: .venv/bin/pip install --upgrade pip pymavlink future
+        # sim_vehicle.py imports pexpect at startup; future is a transitive dep.
+        run: .venv/bin/pip install --upgrade pip pymavlink future pexpect
 
       - name: Build ArduCopter SITL binary
         # Build once; the result is included in the cached ardupilot/ directory.
@@ -117,12 +117,13 @@ jobs:
             --gps-timeout 60 \
             --arm-timeout 90
 
-      - name: Upload telemetry on failure
+      - name: Upload logs on failure
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: telemetry-ardupilot-e2e
+          name: logs-ardupilot-e2e
           path: |
             telemetry.ulg
             telemetry.json
+            /tmp/ap_sitl_stderr.log
           if-no-files-found: ignore

--- a/scripts/e2e_ardupilot_sitl.py
+++ b/scripts/e2e_ardupilot_sitl.py
@@ -166,21 +166,30 @@ def main() -> int:
 
     ap_proc     = None
     simuav_proc = None
+    ap_stderr_log = None
 
     try:
         # 1. Start ArduPilot SITL (headless)
         _info(f"Starting ArduPilot SITL from {args.ardupilot_src} ...")
+        ap_stderr_log = open("/tmp/ap_sitl_stderr.log", "w")
         ap_proc = subprocess.Popen(
             ap_cmd,
             cwd=args.ardupilot_src,
             stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
+            stderr=ap_stderr_log,
         )
 
         # Give ArduPilot time to bind UDP ports before SimUAV connects.
         time.sleep(5)
 
         if ap_proc.poll() is not None:
+            ap_stderr_log.flush()
+            try:
+                with open("/tmp/ap_sitl_stderr.log") as f:
+                    tail = f.read()[-4000:]
+                _info(f"ArduPilot stderr (last 4000 chars):\n{tail}")
+            except OSError:
+                pass
             _die(f"ArduPilot SITL exited early with code {ap_proc.returncode}")
 
         # 2. Start SimUAV with the ArduPilot config
@@ -232,6 +241,11 @@ def main() -> int:
             _terminate(simuav_proc)
         if ap_proc:
             _terminate(ap_proc)
+        try:
+            if ap_stderr_log is not None:
+                ap_stderr_log.close()
+        except Exception:
+            pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- `sim_vehicle.py` imports `pexpect` at module level. The `.venv` used by the E2E test only had `pymavlink` and `future`, so ArduPilot SITL exited immediately with code 2. Fix: add `pexpect` to the pip install step and bump the cache key (`v2` → `v3`) so the next run builds a fresh venv.
- Route ArduPilot SITL stderr to `/tmp/ap_sitl_stderr.log` and print the tail on early exit, mirroring what the PX4 E2E already does. Upload the log as an artifact on failure.

## Test plan

- [ ] Trigger E2E (ArduPilot SITL) workflow manually after merge and confirm SITL starts successfully
- [ ] Verify CI passes on this PR (build-and-test + sanitize)